### PR TITLE
[Fortran] Replace .NEQ. to .NEQV.

### DIFF
--- a/Tests/atomic_capture_assign_expr_and_x.f90
+++ b/Tests/atomic_capture_assign_expr_and_x.f90
@@ -79,7 +79,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_capture_assign_expr_eqv_x.f90
+++ b/Tests/atomic_capture_assign_expr_eqv_x.f90
@@ -94,7 +94,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_capture_assign_expr_neqv_x.f90
+++ b/Tests/atomic_capture_assign_expr_neqv_x.f90
@@ -82,7 +82,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_capture_assign_expr_or_x.f90
+++ b/Tests/atomic_capture_assign_expr_or_x.f90
@@ -83,7 +83,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_capture_assign_x_and_expr.f90
+++ b/Tests/atomic_capture_assign_x_and_expr.f90
@@ -80,7 +80,7 @@ INTEGER FUNCTION test()
   END DO
 
   DO x = 1, LOOPCOUNT
-    IF (totals_comparison(x) .NE. totals(x)) THEN
+    IF (totals_comparison(x) .NEQV. totals(x)) THEN
       errors = errors + 1
       WRITE(*, *) totals_comparison(x)
     END IF

--- a/Tests/atomic_capture_assign_x_eqv_expr.f90
+++ b/Tests/atomic_capture_assign_x_eqv_expr.f90
@@ -94,7 +94,7 @@ INTEGER FUNCTION test()
   END DO
 
   DO x = 1, LOOPCOUNT
-    IF (totals_comparison(x) .NE. totals(x)) THEN
+    IF (totals_comparison(x) .NEQV. totals(x)) THEN
       errors = errors + 1
       WRITE(*, *) totals_comparison(x)
     END IF

--- a/Tests/atomic_capture_assign_x_neqv_expr.f90
+++ b/Tests/atomic_capture_assign_x_neqv_expr.f90
@@ -82,7 +82,7 @@ INTEGER FUNCTION test()
   END DO
 
   DO x = 1, LOOPCOUNT
-    IF (totals_comparison(x) .NE. totals(x)) THEN
+    IF (totals_comparison(x) .NEQV. totals(x)) THEN
       errors = errors + 1
       WRITE(*, *) totals_comparison(x)
     END IF

--- a/Tests/atomic_capture_assign_x_or_expr.f90
+++ b/Tests/atomic_capture_assign_x_or_expr.f90
@@ -83,7 +83,7 @@ INTEGER FUNCTION test()
   END DO
 
   DO x = 1, LOOPCOUNT
-    IF (totals_comparison(x) .NE. totals(x)) THEN
+    IF (totals_comparison(x) .NEQV. totals(x)) THEN
       errors = errors + 1
       WRITE(*, *) totals_comparison(x)
     END IF

--- a/Tests/atomic_capture_expr_and_x_assign.f90
+++ b/Tests/atomic_capture_expr_and_x_assign.f90
@@ -78,7 +78,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_capture_expr_eqv_x_assign.f90
+++ b/Tests/atomic_capture_expr_eqv_x_assign.f90
@@ -94,7 +94,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_capture_expr_neqv_x_assign.f90
+++ b/Tests/atomic_capture_expr_neqv_x_assign.f90
@@ -82,7 +82,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_capture_expr_or_x_assign.f90
+++ b/Tests/atomic_capture_expr_or_x_assign.f90
@@ -83,7 +83,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_capture_x_and_expr_assign.f90
+++ b/Tests/atomic_capture_x_and_expr_assign.f90
@@ -80,7 +80,7 @@ INTEGER FUNCTION test()
   END DO
 
   DO x = 1, LOOPCOUNT
-    IF (totals_comparison(x) .NE. totals(x)) THEN
+    IF (totals_comparison(x) .NEQV. totals(x)) THEN
       errors = errors + 1
       WRITE(*, *) totals_comparison(x)
     END IF

--- a/Tests/atomic_capture_x_eqv_expr_assign.f90
+++ b/Tests/atomic_capture_x_eqv_expr_assign.f90
@@ -94,7 +94,7 @@ INTEGER FUNCTION test()
   END DO
 
   DO x = 1, LOOPCOUNT
-    IF (totals_comparison(x) .NE. totals(x)) THEN
+    IF (totals_comparison(x) .NEQV. totals(x)) THEN
       errors = errors + 1
       WRITE(*, *) totals_comparison(x)
     END IF

--- a/Tests/atomic_capture_x_neqv_expr_assign.f90
+++ b/Tests/atomic_capture_x_neqv_expr_assign.f90
@@ -82,7 +82,7 @@ INTEGER FUNCTION test()
   END DO
 
   DO x = 1, LOOPCOUNT
-    IF (totals_comparison(x) .NE. totals(x)) THEN
+    IF (totals_comparison(x) .NEQV. totals(x)) THEN
       errors = errors + 1
       WRITE(*, *) totals_comparison(x)
     END IF

--- a/Tests/atomic_capture_x_or_expr_assign.f90
+++ b/Tests/atomic_capture_x_or_expr_assign.f90
@@ -83,7 +83,7 @@ INTEGER FUNCTION test()
   END DO
 
   DO x = 1, LOOPCOUNT
-    IF (totals_comparison(x) .NE. totals(x)) THEN
+    IF (totals_comparison(x) .NEQV. totals(x)) THEN
       errors = errors + 1
       WRITE(*, *) totals_comparison(x)
     END IF

--- a/Tests/atomic_expr_and_x.f90
+++ b/Tests/atomic_expr_and_x.f90
@@ -42,7 +42,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_expr_and_x_end.f90
+++ b/Tests/atomic_expr_and_x_end.f90
@@ -43,7 +43,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_expr_eqv_x.f90
+++ b/Tests/atomic_expr_eqv_x.f90
@@ -42,7 +42,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_expr_eqv_x_end.f90
+++ b/Tests/atomic_expr_eqv_x_end.f90
@@ -43,7 +43,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_expr_neqv_x.f90
+++ b/Tests/atomic_expr_neqv_x.f90
@@ -42,7 +42,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_expr_neqv_x_end.f90
+++ b/Tests/atomic_expr_neqv_x_end.f90
@@ -43,7 +43,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_expr_or_x.f90
+++ b/Tests/atomic_expr_or_x.f90
@@ -42,7 +42,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_expr_or_x_end.f90
+++ b/Tests/atomic_expr_or_x_end.f90
@@ -43,7 +43,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_update_expr_and_x.f90
+++ b/Tests/atomic_update_expr_and_x.f90
@@ -42,7 +42,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_update_expr_and_x_end.f90
+++ b/Tests/atomic_update_expr_and_x_end.f90
@@ -43,7 +43,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_update_expr_eqv_x.f90
+++ b/Tests/atomic_update_expr_eqv_x.f90
@@ -42,7 +42,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_update_expr_eqv_x_end.f90
+++ b/Tests/atomic_update_expr_eqv_x_end.f90
@@ -43,7 +43,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_update_expr_neqv_x.f90
+++ b/Tests/atomic_update_expr_neqv_x.f90
@@ -42,7 +42,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_update_expr_neqv_x_end.f90
+++ b/Tests/atomic_update_expr_neqv_x_end.f90
@@ -43,7 +43,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_update_expr_or_x.f90
+++ b/Tests/atomic_update_expr_or_x.f90
@@ -42,7 +42,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_update_expr_or_x_end.f90
+++ b/Tests/atomic_update_expr_or_x_end.f90
@@ -43,7 +43,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_update_x_and_expr.f90
+++ b/Tests/atomic_update_x_and_expr.f90
@@ -42,7 +42,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_update_x_and_expr_end.f90
+++ b/Tests/atomic_update_x_and_expr_end.f90
@@ -43,7 +43,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_update_x_eqv_expr.f90
+++ b/Tests/atomic_update_x_eqv_expr.f90
@@ -42,7 +42,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_update_x_eqv_expr_end.f90
+++ b/Tests/atomic_update_x_eqv_expr_end.f90
@@ -43,7 +43,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_update_x_neqv_expr.f90
+++ b/Tests/atomic_update_x_neqv_expr.f90
@@ -42,7 +42,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_update_x_neqv_expr_end.f90
+++ b/Tests/atomic_update_x_neqv_expr_end.f90
@@ -43,7 +43,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_update_x_or_expr.f90
+++ b/Tests/atomic_update_x_or_expr.f90
@@ -42,7 +42,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_update_x_or_expr_end.f90
+++ b/Tests/atomic_update_x_or_expr_end.f90
@@ -43,7 +43,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_x_and_expr.f90
+++ b/Tests/atomic_x_and_expr.f90
@@ -42,7 +42,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_x_and_expr_end.f90
+++ b/Tests/atomic_x_and_expr_end.f90
@@ -43,7 +43,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_x_eqv_expr.f90
+++ b/Tests/atomic_x_eqv_expr.f90
@@ -42,7 +42,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_x_eqv_expr_end.f90
+++ b/Tests/atomic_x_eqv_expr_end.f90
@@ -43,7 +43,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_x_neqv_expr.f90
+++ b/Tests/atomic_x_neqv_expr.f90
@@ -42,7 +42,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_x_neqv_expr_end.f90
+++ b/Tests/atomic_x_neqv_expr_end.f90
@@ -43,7 +43,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_x_or_expr.f90
+++ b/Tests/atomic_x_or_expr.f90
@@ -42,7 +42,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF

--- a/Tests/atomic_x_or_expr_end.f90
+++ b/Tests/atomic_x_or_expr_end.f90
@@ -43,7 +43,7 @@
         END DO
 
         DO x = 1, LOOPCOUNT
-          IF (totals_comparison(x) .NE. totals(x)) THEN
+          IF (totals_comparison(x) .NEQV. totals(x)) THEN
             errors = errors + 1
             WRITE(*, *) totals_comparison(x)
           END IF


### PR DESCRIPTION
Some of the Fortran tests are using `.NEQ.` for nonequivalence logical comparison.
According to the Fortran standard, the correct equivalence/nonequivalence operators are `.EQV.`/`.NEQV.` accordingly. Using `.NEQ.` works in some compilers but it is not pure standard.

fortran-9 error: 
```
logical_bug.f90:7:8:

    7 |     if (totals_comparison(x) .NE. totals(x)) then
      |        1
Error: Logicals at (1) must be compared with .neqv. instead of .ne.
```

