### PR TITLE
Updated acc_malloc with new behavior: 3.1 --> 3.2

### DIFF
--- a/Tests/acc_malloc.c
+++ b/Tests/acc_malloc.c
@@ -17,6 +17,17 @@ int test1(){
     return err;
 }
 #endif
+#ifndef T2
+//T2:runtime,data,executable-data,V:3.2
+int test2() {
+    int err = 0;
+    int *a = (int *)acc_malloc(0);
+    if (a != NULL) {
+        err += 1;
+    }
+    return err;
+}
+#endif 
 
 int main(){
     int failcode = 0;
@@ -28,6 +39,15 @@ int main(){
     }
     if (failed != 0){
         failcode = failcode + (1 << 0);
+    }
+#endif
+#ifndef T2
+    failed = 0;
+    for (int x = 0; x < NUM_TEST_CALLS; x++) {
+        failed = failed + test2();
+    }
+    if (failed != 0) {
+        failcode = failcode + (1 << 1);
     }
 #endif
     return failcode;


### PR DESCRIPTION
3.1 --> 3.2 Update:
3.2.16 defines new behavior for acc_malloc:
If the bytes value passed into acc_malloc is zero, a null pointer should be returned.