### PR TITLE
Fix atomic_capture_expr_plus_x.c totals subarray

### DIFF
--- a/Tests/atomic_capture_expr_plus_x.c
+++ b/Tests/atomic_capture_expr_plus_x.c
@@ -51,7 +51,7 @@ int test1(){
         totals_comparison[x] = 0;
     }
 
-    #pragma acc data copyin(a[0:n], b[0:n]) copy(totals[0:10]) copyout(c[0:n])
+    #pragma acc data copyin(a[0:n], b[0:n]) copy(totals[0:11]) copyout(c[0:n])
     {
         #pragma acc parallel
         {


### PR DESCRIPTION
`totals` is allocated with 11 elements on the host.  All 11 elements are accessed in the parallel construct, but only 10 are allocated on the device by the `copy` clause.