### PR TITLE
New Fortran Routine Test for acc_hostptr

### DIFF
--- a/Tests/acc_hostptr.F90
+++ b/Tests/acc_hostptr.F90
@@ -1,0 +1,51 @@
+#ifndef T1
+!T1:runtime,data,V:3.3
+    LOGICAL FUNCTION test1()
+        USE OPENACC
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        REAL,  DIMENSION(LOOPCOUNT) :: a !Data
+        INTEGER :: err = 0
+
+        CALL acc_create(a)
+
+        IF (a /= acc_hostptr(a)) THEN
+                err = err + 1
+        END IF
+
+        CALL acc_delete()
+
+        IF (err .eq. 0) THEN
+          test1 = .FALSE.
+        ELSE
+          test1 = .TRUE.
+        END IF
+      END
+#endif
+
+     PROGRAM main
+        IMPLICIT NONE
+        INTEGER :: failcode, testrun
+        LOGICAL :: failed
+        INCLUDE "acc_testsuite.Fh"
+        !Conditionally define test functions
+#ifndef T1
+        LOGICAL :: test1
+#endif
+        failcode = 0
+        failed = .FALSE.
+
+#ifndef T1
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .or. test1()
+        END DO
+        IF (failed) THEN
+          failcode = failcode + 2 ** 0
+          failed = .FALSE.
+        END IF
+#endif
+        CALL EXIT (failcode)
+      END PROGRAM
+
+
+


### PR DESCRIPTION
OpenACC Spec V: 3.3
Feature is unimplemented, as well as the use of acc_create and acc_delete in this test
Tested using NVHPC/23.5 on V100