### PR TITLE
Remove VALUE attribute from non dummy arguments

### DIFF
--- a/Tests/acc_deviceptr.F90
+++ b/Tests/acc_deviceptr.F90
@@ -7,7 +7,7 @@
         REAL(8), DIMENSION(LOOPCOUNT) :: a, b, c  !Data
         REAL(8), POINTER, DIMENSION(:) :: a_ptr, b_ptr, d_ptr
         INTEGER :: errors = 0
-        INTEGER, value :: x, i
+        INTEGER :: x, i
 
         !Initilization
         SEEDDIM(1) = 1


### PR DESCRIPTION
This patch fixes #59. The `VALUE` attribute should not be used on non dummy argument variable. 