### PR TITLE
Remove misplaced  acc routine

### DIFF
--- a/Tests/declare_create.F90
+++ b/Tests/declare_create.F90
@@ -2,7 +2,6 @@
 !$acc declare create(scalar)
 !$acc declare create(LOOPCOUNT)
 
-!$acc routine vector
 FUNCTION multiplyData(a)
   REAL(8),DIMENSION(LOOPCOUNT), INTENT(INOUT) :: a
   !$acc loop vector


### PR DESCRIPTION
This patch fixes #61. The `acc routine` placement here is not following the specification. 