### PR TITLE
Fix invalid lower bound

### DIFF
--- a/Tests/acc_deviceptr.F90
+++ b/Tests/acc_deviceptr.F90
@@ -23,7 +23,7 @@
             c(i) = 0
         END DO
 
-        !$acc enter data copyin(a(0:n), b(0:n)) create(c(0:n))
+        !$acc enter data copyin(a(1:n), b(1:n)) create(c(1:n))
 
         a_ptr = acc_deviceptr(a)
         b_ptr = acc_deviceptr(b)
@@ -39,7 +39,7 @@
             !$acc end parallel
         !$acc end data
 
-        !$acc exit data copyout(c(0:n)) delete(a(0:n), b(0:n))
+        !$acc exit data copyout(c(1:n)) delete(a(1:n), b(1:n))
 
         DO x = 0, LOOPCOUNT
             IF (ABS(c(x) - (a(x) + b(x))) .gt. PRECISION) THEN

--- a/Tests/acc_map_data.F90
+++ b/Tests/acc_map_data.F90
@@ -30,7 +30,7 @@
         !$acc end data
 
 
-        !$acc update host(c(0:LOOPCOUNT))
+        !$acc update host(c(1:LOOPCOUNT))
         DO x = 1, LOOPCOUNT
             IF (ABS(c(x) - (a(x) + b(x))) .gt. PRECISION) THEN
             errors = errors + 1

--- a/Tests/acc_unmap_data.F90
+++ b/Tests/acc_unmap_data.F90
@@ -20,7 +20,7 @@
 
         CALL acc_map_data(C_LOC(c), C_LOC(d), LOOPCOUNT)
 
-        !$acc data copyin(a(0:LOOPCOUNT), b(0:LOOPCOUNT)) present(c(0:LOOPCOUNT)) copyout(c(0:LOOPCOUNT))
+        !$acc data copyin(a(1:LOOPCOUNT), b(1:LOOPCOUNT)) present(c(1:LOOPCOUNT)) copyout(c(1:LOOPCOUNT))
             !$acc parallel
                 !$acc loop
                     DO i = 0, LOOPCOUNT


### PR DESCRIPTION
This patch fixes #58. Arrays are declared with default lowerbound of `1`. Arrasy section cannot use lower bound of `0`.