### PR TITLE
Fix call to acc_delete with no arg

### DIFF
--- a/Tests/acc_hostptr.F90
+++ b/Tests/acc_hostptr.F90
@@ -13,7 +13,7 @@
                 err = err + 1
         END IF
 
-        CALL acc_delete()
+        CALL acc_delete(a)
 
         IF (err .eq. 0) THEN
           test1 = .FALSE.


### PR DESCRIPTION
This patch fixes #60. Call to `acc_delete` is missing an argument. 