### PR TITLE
Switch copyin_copyout_test to subroutine

### DIFF
--- a/Tests/declare_function_scope_copy.F90
+++ b/Tests/declare_function_scope_copy.F90
@@ -1,4 +1,4 @@
-FUNCTION copyin_copyout_test(a, b, c, LOOPCOUNT)
+SUBROUTINE copyin_copyout_test(a, b, c, LOOPCOUNT)
   REAL(8),DIMENSION(LOOPCOUNT),INTENT(IN) :: a, b
   REAL(8),DIMENSION(LOOPCOUNT),INTENT(INOUT) :: c
   INTEGER,INTENT(IN) :: LOOPCOUNT
@@ -10,7 +10,7 @@ FUNCTION copyin_copyout_test(a, b, c, LOOPCOUNT)
       c(y) = c(y) + a(y) + b(y)
     END DO
   !$acc end parallel
-END FUNCTION copyin_copyout_test
+END SUBROUTINE copyin_copyout_test
 
 #ifndef T1
 !T1:devonly,construct-independent,declare,V:2.0-2.7


### PR DESCRIPTION
`copyin_copyout_test` is called like a subroutine with the `CALL` statement but it was a function. It seems there is no reason that it is a function because no return value is produced. Switch it to a subroutine so no error are raised on call statements. 

This fixes #62 