### PR TITLE
Fix reference to rank 2 array with a single subscript

### DIFF
--- a/Tests/serial_loop_reduction_bitand_loop.F90
+++ b/Tests/serial_loop_reduction_bitand_loop.F90
@@ -22,10 +22,10 @@
 
   DO y = 1, 10
     DO x = 1, LOOPCOUNT
-      b(x) = INT(10 * randoms(x, y, 17))
+      b(x, y) = INT(10 * randoms(x, y, 17))
       DO z = 1, 16
         IF (randoms(x, y, z) .lt. false_margin) THEN
-          a(x) = a(x) + 2**(z - 1)
+          a(x, y) = a(x, y) + 2**(z - 1)
         END IF
       END DO
     END DO


### PR DESCRIPTION
Array `a` and `b` have rank 2 but they are referenced with a single subscript. Update the test so the array reference have the correct number of subscript. 

This was detected by flang. 