### PR TITLE
Fix mixed comparison logical/integer

### DIFF
--- a/Tests/serial_loop_reduction_and_loop.F90
+++ b/Tests/serial_loop_reduction_and_loop.F90
@@ -44,7 +44,7 @@
       !$acc loop worker
       DO x = 1, LOOPCOUNT
         IF (temp) THEN
-          IF (a(x, y) .eq. 1) THEN
+          IF (a(x, y) .eqv. .TRUE.) THEN
             a(x, y) = .FALSE.
           ELSE
             a(x, y) = .TRUE.


### PR DESCRIPTION
In test `Tests/serial_loop_reduction_and_loop.F90`, there is a mixed comparison between a logical and an integer value. `a` is a logical array and should be compare to logical value with `.eqv.`.