### PR TITLE
Fix declaration of a(N) to a(LOOPCOUNT)

### DIFF
--- a/Tests/serial_loop_reduction_bitand_general.F90
+++ b/Tests/serial_loop_reduction_bitand_general.F90
@@ -3,7 +3,7 @@
       LOGICAL FUNCTION test1()
   IMPLICIT NONE
   INCLUDE "acc_testsuite.Fh"
-  INTEGER,DIMENSION(N):: a
+  INTEGER,DIMENSION(LOOPCOUNT):: a
   INTEGER:: b, host_b
   REAL(8):: false_margin
   REAL(8),DIMENSION(LOOPCOUNT, 16):: randoms


### PR DESCRIPTION
`a` is declared as `a(N)` but is iterated over `LOOPCOUNT`. Also it is in a `copyin` clause with the section `1:LOOPCOUNT`. It seems `a` should be declared as `a(LOOPCOUNT)`. 

If `a` is delcared as `a(N)` the subscript used in the copyin clause is wrong. 