### PR TITLE
serial implicit attributes test update

### DIFF
--- a/Tests/serial_implicit_data_attributes.c
+++ b/Tests/serial_implicit_data_attributes.c
@@ -5,12 +5,24 @@
 int test1(){
 	int err = 0;
 	srand(SEED);
-	int temp = rand()/(real_t)(RAND_MAX / 10);
-	#pragma acc serial default(none) reduction(+:temp)
-	for(int x = 0; x < n; ++x){
-		temp += temp;
+	real_t *a = (real_t *) malloc ( n *sizeof(real_t));
+	real_t temp = 0;
+	real_t sum = 0;
+	
+	for( int x = 0; x < n; ++x){
+		a[x] = rand()/ (real_t)(RAND_MAX/10);
 	}
-	if(temp > PRECISION){
+
+	#pragma acc serial default(none) reduction(+:temp) copy(a[0:n])
+	for(int x = 0; x < n; ++x){
+		temp += a[x];
+	}
+
+	for( int x = 0; x < n; ++x){
+		sum += a[x];
+	}
+
+	if((temp - sum) > PRECISION){ 
 		err = 1;
 	}
 	return err;


### PR DESCRIPTION
Fixed test 1 logic, was unclear before. All tests pass with nvc 23.9 now. 

Some tests are failing with 24.3 but passing with 23.9