### PR TITLE
fixing acc_create tests

### DIFF
--- a/Tests/acc_create.c
+++ b/Tests/acc_create.c
@@ -179,12 +179,12 @@ int test5(){
         for (int x = 0; x < n; ++x){
             a[x] = rand() / (real_t)(RAND_MAX / 10);
             b[x] = rand() / (real_t)(RAND_MAX / 10);
-            c[x] = 1;
+            c[x] = 0;
         }
 
         #pragma acc enter data copyin(c[0:n])
         for (int x = 0; x < n; ++x){
-            c[x] = 0;
+            c[x] = 1;
         }
         acc_create(c, n * sizeof(real_t));
         #pragma acc data copyin(a[0:n], b[0:n])
@@ -202,7 +202,7 @@ int test5(){
         #pragma acc exit data delete(c[0:n])
         
 	for (int x = 0; x < n; ++x) {
-            if (fabs(c[x] - (1 + a[x] + b[x])) > PRECISION) {
+            if ((fabs(c[x] - 1)) > PRECISION) {
                 err += 1;
             }
         }

--- a/Tests/acc_create.cpp
+++ b/Tests/acc_create.cpp
@@ -179,12 +179,12 @@ int test5(){
         for (int x = 0; x < n; ++x){
             a[x] = rand() / (real_t)(RAND_MAX / 10);
             b[x] = rand() / (real_t)(RAND_MAX / 10);
-            c[x] = 1;
+            c[x] = 0;
         }
 
         #pragma acc enter data copyin(c[0:n])
         for (int x = 0; x < n; ++x){
-            c[x] = 0;
+            c[x] = 1;
         }
         acc_create(c, n * sizeof(real_t));
         #pragma acc data copyin(a[0:n], b[0:n])
@@ -201,7 +201,7 @@ int test5(){
         #pragma acc exit data copyout(c[0:n])
     
         for (int x = 0; x < n; ++x) {
-            if (fabs(c[x] - (1 + a[x] + b[x])) > PRECISION) {
+            if (fabs(c[x] - 1) > PRECISION) {
                 err += 1;
             }
         }

--- a/Tests/acc_create_async.c
+++ b/Tests/acc_create_async.c
@@ -213,7 +213,7 @@ int test5(){
         for (int x = 0; x < n; ++x){
             a[x] = rand() / (real_t)(RAND_MAX / 10);
             b[x] = rand() / (real_t)(RAND_MAX / 10);
-            c[x] = 0;
+            c[x] = 1;
         }
 
         #pragma acc enter data create(c[0:n])
@@ -239,7 +239,7 @@ int test5(){
         }
 
         for (int x = 0; x < n; ++x) {
-            if (fabs(c[x] - (2 * (a[x] + b[x]))) > PRECISION) {
+            if (fabs(c[x] - 1) > PRECISION) {
                 err += 1;
             }
         }

--- a/Tests/acc_create_async.cpp
+++ b/Tests/acc_create_async.cpp
@@ -213,7 +213,7 @@ int test5(){
         for (int x = 0; x < n; ++x){
             a[x] = rand() / (real_t)(RAND_MAX / 10);
             b[x] = rand() / (real_t)(RAND_MAX / 10);
-            c[x] = 0;
+            c[x] = 1;
         }
 
         #pragma acc enter data create(c[0:n])
@@ -239,7 +239,7 @@ int test5(){
         }
 
         for (int x = 0; x < n; ++x) {
-            if (fabs(c[x] - (2 * (a[x] + b[x]))) > PRECISION) {
+            if (fabs(c[x] - 1) > PRECISION) {
                 err += 1;
             }
         }


### PR DESCRIPTION
This PR fixes OpenACC reference counting tests for acc_create/acc_create_async to correctly verify that copyout doesn't occur due to reference counting behavior (>0).  Due to reference count being equal to 2 (even after the present decrement action decreases the counter to 1), the copyout will not be performed. The tests now have c[x] initialized to be 1, so that when checked later, c[x] can be compared to a non-zero value.