### PR TITLE
Use '#include <stdbool.h>' instead of a typedef for C23 compat

### DIFF
--- a/Tests/acc_testsuite.h
+++ b/Tests/acc_testsuite.h
@@ -50,7 +50,7 @@ class data_container{
     }
 };
 #else
-typedef enum { false, true } bool;
+#include <stdbool.h>
 #endif
 
 #define ARRAYSIZE_NEW 256

--- a/Tests/acc_testsuite_declare.h
+++ b/Tests/acc_testsuite_declare.h
@@ -111,7 +111,7 @@ class data_container{
     }
 };
 #else
-typedef enum { false, true } bool;
+#include <stdbool.h>
 #endif
 
 #define ARRAYSIZE_NEW 1024


### PR DESCRIPTION
* Fix Issue #91

Since C23, C defines `true` and `false` as keywords to represent predefined constants of type 'bool' (alias _Bool).
C since C99 provides 'stdbool.h' which can be used both with C23 and older C versions; hence, replace all
`typedef enum { false, true } bool;`
by
`#include <stdbool.h>`