### PR TITLE
Copy copyout

### DIFF
--- a/Tests/copy_copyout.c
+++ b/Tests/copy_copyout.c
@@ -1,7 +1,50 @@
 #include "acc_testsuite.h"
 #ifndef T1
-//T1: , V:1.0-2.7
+//T1: , V:1.0-3.3
 int test1(){
+    int err = 0;
+    real_t test = 0;
+    #pragma acc parallel loop copyout(test) copy(test) reduction(+:test)
+    for( int x = 0; x <n; ++x){
+        test += 1;
+    }
+
+    if(fabs(test - n) > PRECISION){
+        err++;
+    }
+
+    return err;
+}
+#endif
+
+#ifndef T2
+//T2: , V:1.0-3.3
+int test2(){
+    int err = 0;
+    real_t *test = (real_t *)malloc(n * sizeof(real_t));
+
+    for(int x = 0; x < n; ++x){
+        test[x] = 1.0;
+    }
+
+   #pragma acc parallel loop copyout(test[0:n]) copy(test[0:n])
+   for(int x = 0; x < n; ++x){
+        test[x] += 1.0;
+   }
+
+   for(int x = 0; x < n; ++x){
+        if(fabs(test[x] - 2.0) > PRECISION){
+            err++;
+        }
+    }
+
+    return err;
+}
+#endif
+
+#ifndef T3
+//T3: , V:1.0-2.7
+int test3(){
     int err = 0;
     real_t test = 0;
     #pragma acc parallel loop copy(test) copyout(test) reduction(+:test)
@@ -17,9 +60,9 @@ int test1(){
 }
 #endif
 
-#ifndef T2
-//T2: , V:1.0-2.7
-int test2(){
+#ifndef T4
+//T4: , V:1.0-2.7
+int test4(){
     int err = 0;
     real_t *test = (real_t *)malloc(n * sizeof(real_t));
 
@@ -27,7 +70,7 @@ int test2(){
         test[x] = 1.0;
     }
 
-   #pragma acc parallel loop copy(test[0:n]) copyout(test[0:n])
+   #pragma acc parallel loop copy(test[0:n]) copyout(test[0:n]) 
    for(int x = 0; x < n; ++x){
         test[x] += 1.0;
    }
@@ -47,20 +90,38 @@ int main(){
     int failed;
 #ifndef T1
     failed = 0;
-    for( int x = 0; x < NUM_TEST_CALLS; ++x){
-	failed += test1();
+    for (int x = 0; x < NUM_TEST_CALLS; ++x){
+        failed = failed + test1();
     }
-    if(failed){
-	failcode += (1 << 0);
+    if (failed != 0){
+        failcode = failcode + (1 << 0);
     }
 #endif
 #ifndef T2
     failed = 0;
-    for( int x = 0; x < NUM_TEST_CALLS; ++x){
-        failed += test2();
+    for (int x = 0; x < NUM_TEST_CALLS; ++x){
+        failed = failed + test2();
     }
-    if(failed){
-        failcode += (1 << 1);
+    if (failed != 0){
+        failcode = failcode + (1 << 1);
+    }
+#endif
+#ifndef T3
+    failed = 0;
+    for (int x = 0; x < NUM_TEST_CALLS; ++x){
+        failed = failed + test3();
+    }
+    if (failed != 0){
+        failcode = failcode + (1 << 2);
+    }
+#endif
+#ifndef T4
+    failed = 0;
+    for (int x = 0; x < NUM_TEST_CALLS; ++x){
+        failed = failed + test4();
+    }
+    if (failed != 0){
+        failcode = failcode + (1 << 3);
     }
 #endif
     return failcode;

--- a/Tests/copy_copyout.c
+++ b/Tests/copy_copyout.c
@@ -1,6 +1,14 @@
 #include "acc_testsuite.h"
 #ifndef T1
 //T1: , V:1.0-3.3
+
+/*
+Performs a scalar summation using a parallel loop with both copyout(test) and copy(test) 
+along with a reduction(+:test) clause. Verifies that the compiler correctly handles 
+combined data clauses during scalar reduction. Test checks to make sure, variable "tests"
+is equal to value of n
+*/
+
 int test1(){
     int err = 0;
     real_t test = 0;
@@ -19,6 +27,14 @@ int test1(){
 
 #ifndef T2
 //T2: , V:1.0-3.3
+
+/*
+Initializes an array of 1.0s, then uses a parallel loop with both copyout(test[0:n]) 
+and copy(test[0:n]) to increment each element. Checks whether the final values are 
+correctly updated to 2.0. Verifies that the compiler correctly handles combined data 
+clauses using arrays
+*/
+
 int test2(){
     int err = 0;
     real_t *test = (real_t *)malloc(n * sizeof(real_t));
@@ -44,6 +60,11 @@ int test2(){
 
 #ifndef T3
 //T3: , V:1.0-2.7
+
+/* 
+Identical to T1 but swaps the order of copy and copyout clauses. 
+*/
+
 int test3(){
     int err = 0;
     real_t test = 0;
@@ -62,6 +83,11 @@ int test3(){
 
 #ifndef T4
 //T4: , V:1.0-2.7
+
+/* 
+Identical to T2 but swaps the order of copy and copyout clauses. 
+*/
+
 int test4(){
     int err = 0;
     real_t *test = (real_t *)malloc(n * sizeof(real_t));

--- a/Tests/copy_copyout.cpp
+++ b/Tests/copy_copyout.cpp
@@ -1,7 +1,50 @@
 #include "acc_testsuite.h"
 #ifndef T1
-//T1: , V:1.0-2.7
+//T1: , V:1.0-3.3
 int test1(){
+    int err = 0;
+    real_t test = 0;
+    #pragma acc parallel loop copyout(test) copy(test) reduction(+:test)
+    for( int x = 0; x <n; ++x){
+        test += 1;
+    }
+
+    if(fabs(test - n) > PRECISION){
+        err++;
+    }
+
+    return err;
+}
+#endif
+
+#ifndef T2
+//T2: , V:1.0-3.3
+int test2(){
+    int err = 0;
+    real_t *test = new real_t[n];
+
+    for(int x = 0; x < n; ++x){
+        test[x] = 1.0;
+    }
+
+   #pragma acc parallel loop copyout(test[0:n]) copy(test[0:n])
+   for(int x = 0; x < n; ++x){
+        test[x] += 1.0;
+   }
+
+   for(int x = 0; x < n; ++x){
+        if(fabs(test[x] - 2.0) > PRECISION){
+            err++;
+        }
+    }
+
+    return err;
+}
+#endif
+
+#ifndef T3
+//T3: , V:1.0-2.7
+int test3(){
     int err = 0;
     real_t test = 0;
     #pragma acc parallel loop copy(test) copyout(test) reduction(+:test)
@@ -17,9 +60,9 @@ int test1(){
 }
 #endif
 
-#ifndef T2
-//T2: , V:1.0-2.7
-int test2(){
+#ifndef T4
+//T4: , V:1.0-2.7
+int test4(){
     int err = 0;
     real_t *test = new real_t[n];
 
@@ -48,10 +91,10 @@ int main(){
 #ifndef T1
     failed = 0;
     for( int x = 0; x < NUM_TEST_CALLS; ++x){
-	failed += test1();
+        failed += test1();
     }
     if(failed){
-	failcode += (1 << 0);
+        failcode += (1 << 0);
     }
 #endif
 #ifndef T2
@@ -61,6 +104,24 @@ int main(){
     }
     if(failed){
         failcode += (1 << 1);
+    }
+#endif
+#ifndef T3
+    failed = 0;
+    for( int x = 0; x < NUM_TEST_CALLS; ++x){
+        failed += test3();
+    }
+    if(failed){
+        failcode += (1 << 2);
+    }
+#endif
+#ifndef T4
+    failed = 0;
+    for( int x = 0; x < NUM_TEST_CALLS; ++x){
+        failed += test4();
+    }
+    if(failed){
+        failcode += (1 << 3);
     }
 #endif
     return failcode;

--- a/Tests/copy_copyout.cpp
+++ b/Tests/copy_copyout.cpp
@@ -1,6 +1,14 @@
 #include "acc_testsuite.h"
 #ifndef T1
 //T1: , V:1.0-3.3
+
+/*
+Performs a scalar summation using a parallel loop with both copyout(test) and copy(test) 
+along with a reduction(+:test) clause. Verifies that the compiler correctly handles 
+combined data clauses during scalar reduction. Test checks to make sure, variable "tests"
+is equal to value of n
+*/
+
 int test1(){
     int err = 0;
     real_t test = 0;
@@ -19,6 +27,14 @@ int test1(){
 
 #ifndef T2
 //T2: , V:1.0-3.3
+
+/*
+Initializes an array of 1.0s, then uses a parallel loop with both copyout(test[0:n]) 
+and copy(test[0:n]) to increment each element. Checks whether the final values are 
+correctly updated to 2.0. Verifies that the compiler correctly handles combined data 
+clauses using arrays
+*/
+
 int test2(){
     int err = 0;
     real_t *test = new real_t[n];
@@ -44,6 +60,11 @@ int test2(){
 
 #ifndef T3
 //T3: , V:1.0-2.7
+
+/* 
+Identical to T1 but swaps the order of copy and copyout clauses. 
+*/
+
 int test3(){
     int err = 0;
     real_t test = 0;
@@ -62,6 +83,11 @@ int test3(){
 
 #ifndef T4
 //T4: , V:1.0-2.7
+
+/* 
+Identical to T2 but swaps the order of copy and copyout clauses. 
+*/
+
 int test4(){
     int err = 0;
     real_t *test = new real_t[n];


### PR DESCRIPTION
This test program is designed to evaluate the behavior of using copy and copyout clauses together in OpenACC directives (#pragma acc parallel loop). Each test function performs simple computations on scalar or array variables, transferring data to and from the GPU using both copy and copyout on the same variable. The goal is to verify whether these clauses work together, and to ensure the ordering of the clause does not matter.

The use of copy and copyout is defined but the order in which they execute is not defined. As a result, some compilers may fail while others may produce correct results.

T1 and T3 tests scalar addition using a parallel loop with both copy and copyout clauses and a reduction. Checks if the final value matches n. (The Order of the clauses is just reversed)

T2 and T4 tests element-wise addition on an array with both copy and copyout clauses. Verifies that each element is incremented correctly from 1.0 to 2.0. (The Order of the clauses is just reversed)