### PR TITLE
Changes to acc_malloc and acc_free

### DIFF
--- a/Tests/acc_free.F90
+++ b/Tests/acc_free.F90
@@ -1,24 +1,29 @@
 #ifndef T1
 !T1:runtime,data,executable-data,V:3.3
+
+! Performs a device memory allocation and deallocation using acc_malloc and acc_free. 
+! Captures the amount of free memory on the device before and after allocation to ensure 
+! that memory is correctly freed. Test checks that device memory usage is restored 
+! after deallocation.
+
       LOGICAL FUNCTION test1()
+        USE ISO_C_BINDING
         USE OPENACC
         IMPLICIT NONE
         INCLUDE "acc_testsuite.Fh"
-        REAL(8),DIMENSION(LOOPCOUNT):: initial_memory, final_memory !Data
-        INTEGER, POINTER :: a(:)
+        TYPE(C_PTR) :: a
+        INTEGER(C_SIZE_T) :: initial_memory, final_memory
         INTEGER :: errors = 0
 
-        initial_memory = acc_get_property(acc_get_device_num(acc_get_device_type()), acc_get_device_type(), acc_property_free_memory);
+        initial_memory = acc_get_property(acc_get_device_num(acc_get_device_type()), acc_get_device_type(), acc_property_free_memory)
         
-        ALLOCATE(a(n))
+        a = acc_malloc(n * C_SIZEOF(0_C_INT))
 
         CALL acc_free(a)
 
-        final_memory = acc_get_property(acc_get_device_num(acc_get_device_type()), acc_get_device_type(), acc_property_free_memory);
+        final_memory = acc_get_property(acc_get_device_num(acc_get_device_type()), acc_get_device_type(), acc_property_free_memory)
 
-        ALLOCATE(a(N))
-
-        IF (final_memory .lt. (initial_memory + size(a))) THEN
+        IF (initial_memory - final_memory > PRECISION) THEN
             errors = errors + 1
         END IF
 

--- a/Tests/acc_malloc.F90
+++ b/Tests/acc_malloc.F90
@@ -1,30 +1,36 @@
 #ifndef T1
 !T1:runtime,construct-independent,internal-control-values,init,nonvalidating,V:3.3
+
+! Validates device memory allocation using acc_malloc and the correctness of acc_free behavior.
+! Captures the initial and final available device memory and ensures that acc_malloc returns a
+! valid pointer. The test confirms that memory was allocated and subsequently released, by
+! verifying pointer association and comparing memory availability before and after allocation.
+! Failure is recorded if the pointer is not associated or memory accounting appears incorrect.
+
       LOGICAL FUNCTION test1()
+        USE ISO_C_BINDING
         USE OPENACC
         IMPLICIT NONE
         INCLUDE "acc_testsuite.Fh"
-        REAL(8),DIMENSION(LOOPCOUNT):: initial_memory, final_memory !Data
-        INTEGER, POINTER :: a(:)
+        INTEGER(C_SIZE_T) :: initial_memory, final_memory
+        TYPE(C_PTR) :: a
         INTEGER :: errors = 0
 
         initial_memory = acc_get_property(acc_get_device_num(acc_get_device_type()), acc_get_device_type(), acc_property_free_memory)
         
-        CALL acc_malloc(a(N))
+        a = acc_malloc(n * C_SIZEOF(0_C_INT))
 
-        IF (initial_memory .ne. 0) THEN
-          test1 = .FALSE.
+        IF (.NOT. C_ASSOCIATED(a)) THEN
+            errors = errors + 1
         END IF
 
         final_memory = acc_get_property(acc_get_device_num(acc_get_device_type()), acc_get_device_type(), acc_property_free_memory)
 
-        DO x = 1, LOOPCOUNT
-          IF (final_memory + N * sizeof(a(1)) .gt. initial_memory) THEN
+        IF (initial_memory - final_memory > PRECISION) THEN
             errors = errors + 1
-          END IF
-        END DO
+        END IF
 
-        CALL acc_free(a(N))
+        CALL acc_free(a)
 
         IF (errors .eq. 0) THEN
           test1 = .FALSE.
@@ -57,5 +63,3 @@
 #endif
         CALL EXIT (failcode)
       END PROGRAM
-
-


### PR DESCRIPTION
#89 

Updated test replaces the incorrect usage of acc_malloc and acc_free from earlier versions.
The original test used an INTEGER POINTER and assumed acc_malloc could directly allocate into Fortran arrays, which is not valid. It also passed incompatible types to acc_free.

In the revised version, acc_malloc is properly used to return a C_PTR as specified by
the OpenACC API, and acc_free is correctly called with an argument of TYPE(C_PTR).
The test now uses ISO_C_BINDING to ensure type safety and portability, computing
allocation size using C_SIZEOF and ensuring the size is passed as a C_SIZE_T.

Additionally, the test checks pointer validity using C_ASSOCIATED and validates memory
restoration using precise comparisons between initial and final free memory values. 