### PR TITLE
Correct use of 'devnum' in wait_devnum.c

### DIFF
--- a/Tests/wait_devnum.c
+++ b/Tests/wait_devnum.c
@@ -28,7 +28,7 @@ int test1(){
             a[i] *= 2;
         }
 
-        #pragma acc wait(devnum:0, queues:1) async(2)
+        #pragma acc wait(devnum:0 : queues:1) async(2)
         #pragma acc parallel loop async(2)
         for(int i = 0; i < n; ++i){
             b[i] = a[i];


### PR DESCRIPTION
The grammar production in the standard for 'wait-argument' is [devnum : int-expr : ] [ queues : ] async-argument-list

So the trailing colon for the devnum is required per spec, but the test uses a comma.  This patch corrects the test by replacing the comma with the colon.