### PR TITLE
Correct set_if tests

### DIFF
--- a/Tests/set_if.c
+++ b/Tests/set_if.c
@@ -7,7 +7,7 @@ int test1(){
 	srand(SEED);
 	int device_type = acc_get_device_type();
 
-	#pragma acc set if(acc_get_device_type == device_type)
+	#pragma acc set if(acc_get_device_type() == device_type) default_async(acc_async_default)
 
 	return err;	
 }
@@ -19,7 +19,7 @@ int test2(){
         srand(SEED);
         int device_type = acc_get_device_type();
 
-        #pragma acc set if(acc_get_device_type != device_type)
+        #pragma acc set if(acc_get_device_type() != device_type) default_async(acc_async_default)
 
         return err;
 }

--- a/Tests/set_if.cpp
+++ b/Tests/set_if.cpp
@@ -7,7 +7,7 @@ int test1(){
 	srand(SEED);
 	int device_type = acc_get_device_type();
 
-	#pragma acc set if(acc_get_device_type == device_type)
+	#pragma acc set if(acc_get_device_type() == device_type) default_async(acc_async_default)
 
 	return err;	
 }
@@ -19,7 +19,7 @@ int test2(){
         srand(SEED);
         int device_type = acc_get_device_type();
 
-        #pragma acc set if(acc_get_device_type != device_type)
+        #pragma acc set if(acc_get_device_type() != device_type) default_async(acc_async_default)
 
         return err;
 }


### PR DESCRIPTION
This patch fixes two problems with the set_if tests:

First, as acc_get_device_type is a function, the comparison was a function-pointer to integer comparison inside the 'if'.  This operation is ill-formed in C++.  However, this patch changes for both the C and C++ test to make sure we call the function instead.

Second, OpenACC's restrictions in the 'set' section (2.14.3 in
    OpenACC3.3) has a restriction of:
"At least one default_async, device_num, or device_type clause must appear".
This patch adds default_async with acc_async_default to both uses of 'set' in both tests.