### PR TITLE
Correct use of 'restrict' in C++ tests.

### DIFF
--- a/Tests/kernels_num_gangs.cpp
+++ b/Tests/kernels_num_gangs.cpp
@@ -4,8 +4,8 @@
 int test1(){
     int err = 0;
     srand(SEED);
-    real_t * restrict a = new real_t[n];
-    real_t * restrict b = new real_t[n];
+    real_t * __restrict a = new real_t[n];
+    real_t * __restrict b = new real_t[n];
 
     for (int x = 0; x < n; ++x){
         a[x] = rand() / (real_t)(RAND_MAX / 10);

--- a/Tests/kernels_num_workers.cpp
+++ b/Tests/kernels_num_workers.cpp
@@ -4,8 +4,8 @@
 int test1(){
     int err = 0;
     srand(SEED);
-    real_t * restrict a = new real_t[n];
-    real_t * restrict b = new real_t[n];
+    real_t * __restrict a = new real_t[n];
+    real_t * __restrict b = new real_t[n];
 
     for (int x = 0; x < n; ++x){
         a[x] = rand() / (real_t)(RAND_MAX / 10);


### PR DESCRIPTION
'restrict' is only a keyword in C, and it is not a conforming extension to support it in C++, so GCC and Clang both diagnose this. However, most compilers expose '__restrict' as an alias for this in a conforming manner.

This patch changes the uses of 'restrict' in C++ tests to '__restrict' so that these tests can compile.