### PR TITLE
Fix two issues in parallel_create_zero

### DIFF
--- a/Tests/parallel_create_zero.c
+++ b/Tests/parallel_create_zero.c
@@ -12,7 +12,7 @@ int Test1(){
         b[x] = 0.0;
     }
 
-    #pragma acc data copyin(a[0:n]) copyout(b[0:n]
+    #pragma acc data copyin(a[0:n]) copyout(b[0:n])
     {
         #pragma acc parallel create(zero: b[0:n])
         {
@@ -40,7 +40,7 @@ int main(){
 #ifndef T1
     failed = 0;
     for (int x = 0; x < NUM_TEST_CALLS; ++x){
-        failed = failed + test1();
+        failed = failed + Test1();
     }
     if (failed != 0){
         failcode = failcode + (1 << 0);

--- a/Tests/parallel_create_zero.cpp
+++ b/Tests/parallel_create_zero.cpp
@@ -12,7 +12,7 @@ int Test1(){
         b[x] = 0.0;
     }
 
-    #pragma acc data copyin(a[0:n]) copyout(b[0:n]
+    #pragma acc data copyin(a[0:n]) copyout(b[0:n])
     {
         #pragma acc parallel create(zero: b[0:n])
         {
@@ -40,7 +40,7 @@ int main(){
 #ifndef T1
     failed = 0;
     for (int x = 0; x < NUM_TEST_CALLS; ++x){
-        failed = failed + test1();
+        failed = failed + Test1();
     }
     if (failed != 0){
         failcode = failcode + (1 << 0);


### PR DESCRIPTION
These tests have a few issues, but this patch fixes two of them:

First, it adds the close paren on the 'copyout' clause that was missing.

Second, it corrects the capitalization on the call to 'Test1', which was resulting in the test not being run properly.

This does NOT fix the ill-formed use of `loop` however.