### PR TITLE
Fix uses of 'loop' to be followed immediately by a loop.

### DIFF
--- a/Tests/data_copyout_zero.c
+++ b/Tests/data_copyout_zero.c
@@ -19,10 +19,8 @@ int test1(){
       #pragma acc parallel
       {
         #pragma acc loop
-        {
-          for (int x = 0; x < n; ++x){
-            b[x] += a[x];
-          }
+        for (int x = 0; x < n; ++x){
+          b[x] += a[x];
         }
       }
     }

--- a/Tests/data_copyout_zero.cpp
+++ b/Tests/data_copyout_zero.cpp
@@ -19,10 +19,8 @@ int test1(){
       #pragma acc parallel
       {
         #pragma acc loop
-        {
-          for (int x = 0; x < n; ++x){
-            b[x] += a[x];
-          }
+        for (int x = 0; x < n; ++x){
+          b[x] += a[x];
         }
       }
     }

--- a/Tests/data_create_zero.c
+++ b/Tests/data_create_zero.c
@@ -18,10 +18,8 @@ int test1(){
       #pragma acc parallel
       {
         #pragma acc loop
-        {
-          for (int x = 0; x < n; ++x){
-            b[x] += a[x];
-          }
+        for (int x = 0; x < n; ++x){
+          b[x] += a[x];
         }
       }
     }

--- a/Tests/data_create_zero.cpp
+++ b/Tests/data_create_zero.cpp
@@ -18,10 +18,8 @@ int test1(){
       #pragma acc parallel
       {
         #pragma acc loop
-        {
-          for (int x = 0; x < n; ++x){
-            b[x] += a[x];
-          }
+        for (int x = 0; x < n; ++x){
+          b[x] += a[x];
         }
       }
     }

--- a/Tests/parallel_copyout_zero.c
+++ b/Tests/parallel_copyout_zero.c
@@ -18,10 +18,8 @@ int test1(){
       #pragma acc parallel copyout(zero: b[0:n])
       {
         #pragma acc loop
-        {
-          for (int x = 0; x < n; ++x){
-            b[x] += a[x];
-          }
+        for (int x = 0; x < n; ++x){
+          b[x] += a[x];
         }
       }
     }
@@ -66,10 +64,8 @@ int test2(){
         #pragma acc parallel copyout(zero: b[0:n])
         {
           #pragma acc loop
-          {
-            for (int x = 0; x < n; ++x){
-              b[x] += a[x];
-            }
+          for (int x = 0; x < n; ++x){
+            b[x] += a[x];
           }
         }
       }
@@ -105,10 +101,8 @@ int test3(){
       #pragma acc parallel copyout(zero: b[0:n])
       {
         #pragma acc loop
-        {
-          for (int x = 0; x < n; ++x){
-            b[x] += a[x];
-          }
+        for (int x = 0; x < n; ++x){
+          b[x] += a[x];
         }
       }
     }

--- a/Tests/parallel_copyout_zero.cpp
+++ b/Tests/parallel_copyout_zero.cpp
@@ -18,10 +18,8 @@ int test1(){
       #pragma acc parallel copyout(zero: b[0:n])
       {
         #pragma acc loop
-        {
-          for (int x = 0; x < n; ++x){
-            b[x] += a[x];
-          }
+        for (int x = 0; x < n; ++x){
+          b[x] += a[x];
         }
       }
     }
@@ -66,10 +64,8 @@ int test2(){
         #pragma acc parallel copyout(zero: b[0:n])
         {
           #pragma acc loop
-          {
-            for (int x = 0; x < n; ++x){
-              b[x] += a[x];
-            }
+          for (int x = 0; x < n; ++x){
+            b[x] += a[x];
           }
         }
       }
@@ -105,10 +101,8 @@ int test3(){
       #pragma acc parallel copyout(zero: b[0:n])
       {
         #pragma acc loop
-        {
-          for (int x = 0; x < n; ++x){
-            b[x] += a[x];
-          }
+        for (int x = 0; x < n; ++x){
+          b[x] += a[x];
         }
       }
     }

--- a/Tests/parallel_create_zero.c
+++ b/Tests/parallel_create_zero.c
@@ -17,10 +17,8 @@ int Test1(){
         #pragma acc parallel create(zero: b[0:n])
         {
             #pragma acc loop
-            {
-                for(int x = 0; x < n; x++){
-                    b[x] += a[x];
-                }
+            for(int x = 0; x < n; x++){
+                b[x] += a[x];
             }
         }
     }

--- a/Tests/parallel_create_zero.cpp
+++ b/Tests/parallel_create_zero.cpp
@@ -17,10 +17,8 @@ int Test1(){
         #pragma acc parallel create(zero: b[0:n])
         {
             #pragma acc loop
-            {
-                for(int x = 0; x < n; x++){
-                    b[x] += a[x];
-                }
+            for(int x = 0; x < n; x++){
+                b[x] += a[x];
             }
         }
     }

--- a/Tests/routine_bind_nonprototype_function_nonstring_function.cpp
+++ b/Tests/routine_bind_nonprototype_function_nonstring_function.cpp
@@ -3,8 +3,8 @@
 //test 1 host function
 #pragma acc routine vector bind(device_array_array)
 real_t host_array_array(real_t * a, long long n){
-    #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+    #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }
@@ -45,8 +45,8 @@ real_t device_object_array(data_container<real_t> *a, long long n){
 //test 3 host function
 #pragma acc routine vector bind(device_array_object)
 real_t host_array_object(real_t * a, long long n){
-   #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+   #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }

--- a/Tests/routine_bind_nonprototype_function_nonstring_lambda.cpp
+++ b/Tests/routine_bind_nonprototype_function_nonstring_lambda.cpp
@@ -3,8 +3,8 @@
 //test 1 host function
 #pragma acc routine vector bind(device_array_array)
 real_t host_array_array(real_t * a, long long n){
-    #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+    #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }
@@ -45,8 +45,8 @@ auto device_object_array = [](data_container<real_t> *a, long long n){
 //test 3 host function
 #pragma acc routine vector bind(device_array_object)
 real_t host_array_object(real_t * a, long long n){
-   #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+   #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }

--- a/Tests/routine_bind_nonprototype_function_string_function.cpp
+++ b/Tests/routine_bind_nonprototype_function_string_function.cpp
@@ -3,8 +3,8 @@
 //test 1 host function
 #pragma acc routine vector bind("device_array_array")
 real_t host_array_array(real_t * a, long long n){
-    #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+    #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }
@@ -45,8 +45,8 @@ real_t device_object_array(data_container<real_t> *a, long long n){
 //test 3 host function
 #pragma acc routine vector bind("device_array_object")
 real_t host_array_object(real_t * a, long long n){
-   #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+   #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }

--- a/Tests/routine_bind_nonprototype_function_string_lambda.cpp
+++ b/Tests/routine_bind_nonprototype_function_string_lambda.cpp
@@ -3,8 +3,8 @@
 //test 1 host function
 #pragma acc routine vector bind("device_array_array")
 real_t host_array_array(real_t * a, long long n){
-    #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+    #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }
@@ -45,8 +45,8 @@ auto device_object_array = [](data_container<real_t> *a, long long n){
 //test 3 host function
 #pragma acc routine vector bind("device_array_object")
 real_t host_array_object(real_t * a, long long n){
-   #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+   #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }

--- a/Tests/routine_bind_nonprototype_lambda_nonstring_function.cpp
+++ b/Tests/routine_bind_nonprototype_lambda_nonstring_function.cpp
@@ -3,8 +3,8 @@
 //test 1 host lambda
 #pragma acc routine vector bind(device_array_array)
 auto  host_array_array = [](real_t * a, long long n){
-    #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+    #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }
@@ -45,8 +45,8 @@ real_t device_object_array(data_container<real_t> *a, long long n){
 //test 3 host lambda
 #pragma acc routine vector bind(device_array_object)
 auto host_array_object = [](real_t * a, long long n){
-   #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+   #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }

--- a/Tests/routine_bind_nonprototype_lambda_nonstring_lambda.cpp
+++ b/Tests/routine_bind_nonprototype_lambda_nonstring_lambda.cpp
@@ -3,8 +3,8 @@
 //test 1 host lambda
 #pragma acc routine vector bind(device_array_array)
 auto host_array_array = [](real_t * a, long long n){
-    #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+    #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }
@@ -45,8 +45,8 @@ auto device_object_array = [](data_container<real_t> *a, long long n){
 //test 3 host lambda
 #pragma acc routine vector bind(device_array_object)
 auto host_array_object = [](real_t * a, long long n){
-   #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+   #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }

--- a/Tests/routine_bind_nonprototype_lambda_string_function.cpp
+++ b/Tests/routine_bind_nonprototype_lambda_string_function.cpp
@@ -3,8 +3,8 @@
 //test 1 host lambnda
 #pragma acc routine vector bind("device_array_array")
 auto  host_array_array = [](real_t * a, long long n){
-    #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+    #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }
@@ -45,8 +45,8 @@ real_t device_object_array(data_container<real_t> *a, long long n){
 //test 3 host lambda
 #pragma acc routine vector bind("device_array_object")
 auto host_array_object = [](real_t * a, long long n){
-   #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+   #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }

--- a/Tests/routine_bind_nonprototype_lambda_string_lambda.cpp
+++ b/Tests/routine_bind_nonprototype_lambda_string_lambda.cpp
@@ -3,8 +3,8 @@
 //test 1 host lambda
 #pragma acc routine vector bind("device_array_array")
 auto host_array_array = [](real_t * a, long long n){
-    #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+    #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }
@@ -45,8 +45,8 @@ auto device_object_array = [](data_container<real_t> *a, long long n){
 //test 3 host lambda
 #pragma acc routine vector bind("device_array_object")
 auto host_array_object = [](real_t * a, long long n){
-   #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+   #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }

--- a/Tests/routine_bind_prototype_function_nonstring_function.cpp
+++ b/Tests/routine_bind_prototype_function_nonstring_function.cpp
@@ -2,8 +2,8 @@
 
 //test 1 host function
 real_t host_array_array(real_t * a, long long n){
-    #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+    #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }
@@ -22,8 +22,8 @@ real_t host_object_array(data_container<real_t> * a, long long n){
 
 //test 3 host function
 real_t host_array_object(real_t * a, long long n){
-   #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+   #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }

--- a/Tests/routine_bind_prototype_function_nonstring_lambda.cpp
+++ b/Tests/routine_bind_prototype_function_nonstring_lambda.cpp
@@ -2,8 +2,8 @@
 
 //test 1 host function
 real_t host_array_array(real_t * a, long long n){
-    #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+    #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }
@@ -22,8 +22,8 @@ real_t host_object_array(data_container<real_t> * a, long long n){
 
 //test 3 host function
 real_t host_array_object(real_t * a, long long n){
-   #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+   #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }

--- a/Tests/routine_bind_prototype_function_string_function.cpp
+++ b/Tests/routine_bind_prototype_function_string_function.cpp
@@ -2,8 +2,8 @@
 
 //test 1 host function
 real_t host_array_array(real_t * a, long long n){
-    #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+    #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }
@@ -22,8 +22,8 @@ real_t host_object_array(data_container<real_t> * a, long long n){
 
 //test 3 host function
 real_t host_array_object(real_t * a, long long n){
-   #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+   #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }

--- a/Tests/routine_bind_prototype_function_string_lambda.cpp
+++ b/Tests/routine_bind_prototype_function_string_lambda.cpp
@@ -2,8 +2,8 @@
 
 //test 1 host function
 real_t host_array_array(real_t * a, long long n){
-    #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+    #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }
@@ -22,8 +22,8 @@ real_t host_object_array(data_container<real_t> * a, long long n){
 
 //test 3 host function
 real_t host_array_object(real_t * a, long long n){
-   #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+   #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }

--- a/Tests/routine_bind_prototype_lambda_nonstring_function.cpp
+++ b/Tests/routine_bind_prototype_lambda_nonstring_function.cpp
@@ -2,8 +2,8 @@
 
 //test 1 host lambda
 auto host_array_array = [](real_t * a, long long n){
-    #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+    #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }
@@ -22,8 +22,8 @@ auto  host_object_array= [](data_container<real_t> * a, long long n){
 
 //test 3 host lambda
 auto host_array_object = [](real_t * a, long long n){
-   #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+   #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }

--- a/Tests/routine_bind_prototype_lambda_nonstring_lambda.cpp
+++ b/Tests/routine_bind_prototype_lambda_nonstring_lambda.cpp
@@ -2,8 +2,8 @@
 
 //test 1 host lambda
 auto host_array_array = [](real_t * a, long long n){
-    #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+    #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }
@@ -22,8 +22,8 @@ auto host_object_array = [](data_container<real_t> * a, long long n){
 
 //test 3 host lambda
 auto host_array_object = [](real_t * a, long long n){
-   #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+   #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }

--- a/Tests/routine_bind_prototype_lambda_string_function.cpp
+++ b/Tests/routine_bind_prototype_lambda_string_function.cpp
@@ -2,8 +2,8 @@
 
 //test 1 host lambda
 auto host_array_array = [](real_t * a, long long n){
-    #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+    #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }
@@ -22,8 +22,8 @@ auto host_object_array = [](data_container<real_t> * a, long long n){
 
 //test 3 host lambda
 auto host_array_object = [](real_t * a, long long n){
-   #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+   #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }

--- a/Tests/routine_bind_prototype_lambda_string_lambda.cpp
+++ b/Tests/routine_bind_prototype_lambda_string_lambda.cpp
@@ -2,8 +2,8 @@
 
 //test 1 host lambda
 auto host_array_array = [](real_t * a, long long n){
-    #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+    #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }
@@ -22,8 +22,8 @@ auto host_object_array = [](data_container<real_t> * a, long long n){
 
 //test 3 host lambda
 auto host_array_object = [](real_t * a, long long n){
-   #pragma acc loop reduction(+:returned)
     real_t returned = 0.0;
+   #pragma acc loop reduction(+:returned)
     for (int x = 0; x < n; ++x){
         returned += a[x];
     }


### PR DESCRIPTION
The OpenACC 3.3 spec says (2.9 summary): The OpenACC loop construct
                                         applies to a loop which must
                                         immediately follow this
                                         directive.

This patch fixes all(hopefully!) violations of this problem.