### PR TITLE
New pqr list test

### DIFF
--- a/Tests/acc_pqr_list.F90
+++ b/Tests/acc_pqr_list.F90
@@ -1,13 +1,15 @@
 ! acc_pqr_list.F90
-! Validates correct usage of OpenACC pqr-lists in Fortran as clarified in OpenACC 3.4 Section 1.6.
-! Confirms that pqr-lists used in OpenACC directives:
-!   - contain one or more items
-!   - do not include trailing commas
-! The tests exercise valid var-list pqr-lists in data clauses (copyin, copy)
-! and valid int-expr-list pqr-lists in synchronization clauses (wait),
-! using both single-item and multi-item lists.
-! Correctness is verified at runtime by comparing device-computed results
-! with expected host values.
+!
+! Feature under test (OpenACC 3.4, Section 1.6):
+! - A pqr-list must contain at least one item.
+! - A pqr-list must not have a trailing comma.
+!
+! This test exercises valid pqr-list usage in:
+!   - var-lists (copyin, copy)
+!   - int-expr-lists (wait)
+!
+! Only spec-compliant (non-empty, no trailing comma) forms are used.
+
 
 #ifndef T1
 !T1:syntax,pqr-list,runtime,construct-independent,V:3.4-

--- a/Tests/acc_pqr_list.F90
+++ b/Tests/acc_pqr_list.F90
@@ -4,11 +4,12 @@
 ! - A pqr-list must contain at least one item.
 ! - A pqr-list must not have a trailing comma.
 !
-! This test exercises valid pqr-list usage in:
-!   - var-lists (copyin, copy)
-!   - int-expr-lists (wait)
+! Notes:
+!   T1: int-expr-list is non-empty (single-item list)
+!   T2: int-expr-list has no trailing comma (multi-item list)
+!   T3: var-list is non-empty (single-item list)
+!   T4: var-list has no trailing comma (multi-item list)
 !
-! Only spec-compliant (non-empty, no trailing comma) forms are used.
 
 
 #ifndef T1
@@ -44,7 +45,9 @@
         !$acc end data
 
         DO i = 1, LOOPCOUNT
-          IF (ABS(c(i) - (a(i) + b(i))) .GT. PRECISION) errors = errors + 1
+          IF (ABS(c(i) - (a(i) + b(i))) .GT. PRECISION) THEN
+            errors = errors + 1
+          END IF
         END DO
 
         test1 = (errors .NE. 0)
@@ -91,7 +94,9 @@
         !$acc end data
 
         DO i = 1, LOOPCOUNT
-          IF (ABS(c(i) - (a(i) + b(i))) .GT. PRECISION) errors = errors + 1
+          IF (ABS(c(i) - (a(i) + b(i))) .GT. PRECISION) THEN
+            errors = errors + 1
+          END IF
         END DO
 
         test2 = (errors .NE. 0)
@@ -128,7 +133,9 @@
         !$acc end data
 
         DO i = 1, LOOPCOUNT
-          IF (ABS(c(i) - (2.0D0 * a(i))) .GT. PRECISION) errors = errors + 1
+          IF (ABS(c(i) - (2.0D0 * a(i))) .GT. PRECISION) THEN
+            errors = errors + 1
+          END IF
         END DO
 
         test3 = (errors .NE. 0)
@@ -166,7 +173,9 @@
         !$acc end data
 
         DO i = 1, LOOPCOUNT
-          IF (ABS(c(i) - (a(i) + b(i))) .GT. PRECISION) errors = errors + 1
+          IF (ABS(c(i) - (a(i) + b(i))) .GT. PRECISION) THEN
+            errors = errors + 1
+          END IF
         END DO
 
         test4 = (errors .NE. 0)
@@ -198,7 +207,9 @@
         DO testrun = 1, NUM_TEST_CALLS
           failed = failed .OR. test1()
         END DO
-        IF (failed) failcode = failcode + 2**0
+        IF (failed) THEN
+          failcode = failcode + 2**0
+        END IF
 #endif
 
 #ifndef T2
@@ -206,7 +217,9 @@
         DO testrun = 1, NUM_TEST_CALLS
           failed = failed .OR. test2()
         END DO
-        IF (failed) failcode = failcode + 2**1
+        IF (failed) THEN
+          failcode = failcode + 2**1
+        END IF
 #endif
 
 #ifndef T3
@@ -214,7 +227,9 @@
         DO testrun = 1, NUM_TEST_CALLS
           failed = failed .OR. test3()
         END DO
-        IF (failed) failcode = failcode + 2**2
+        IF (failed) THEN
+          failcode = failcode + 2**2
+        END IF
 #endif
 
 #ifndef T4
@@ -222,7 +237,9 @@
         DO testrun = 1, NUM_TEST_CALLS
           failed = failed .OR. test4()
         END DO
-        IF (failed) failcode = failcode + 2**3
+        IF (failed) THEN
+          failcode = failcode + 2**3
+        END IF
 #endif
 
         CALL EXIT(failcode)

--- a/Tests/acc_pqr_list.F90
+++ b/Tests/acc_pqr_list.F90
@@ -1,6 +1,6 @@
 ! acc_pqr_list.F90
 !
-! Feature under test (OpenACC 3.4, Section 1.6):
+! Feature under test (OpenACC 3.4, Section 1.6, Feb 2026):
 ! - A pqr-list must contain at least one item.
 ! - A pqr-list must not have a trailing comma.
 !

--- a/Tests/acc_pqr_list.F90
+++ b/Tests/acc_pqr_list.F90
@@ -1,0 +1,216 @@
+#ifndef T1
+!T1:syntax,pqr-list,runtime,construct-independent,V:3.4-
+! int-expr-list non-empty via wait(1)
+      LOGICAL FUNCTION test1()
+        USE OPENACC
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: i
+        REAL(8), DIMENSION(LOOPCOUNT) :: a, b, c
+        INTEGER :: errors
+        errors = 0
+
+        SEEDDIM(1) = 1
+#       ifdef SEED
+        SEEDDIM(1) = SEED
+#       endif
+        CALL RANDOM_SEED(PUT=SEEDDIM)
+        CALL RANDOM_NUMBER(a)
+        CALL RANDOM_NUMBER(b)
+        c = 0.0D0
+
+        !$acc data copyin(a(1:LOOPCOUNT), b(1:LOOPCOUNT)) copy(c(1:LOOPCOUNT))
+          !$acc parallel present(a(1:LOOPCOUNT), b(1:LOOPCOUNT), c(1:LOOPCOUNT)) async(1)
+            !$acc loop
+            DO i = 1, LOOPCOUNT
+              c(i) = a(i) + b(i)
+            END DO
+          !$acc end parallel
+
+          !$acc wait(1)
+        !$acc end data
+
+        DO i = 1, LOOPCOUNT
+          IF (ABS(c(i) - (a(i) + b(i))) .GT. PRECISION) errors = errors + 1
+        END DO
+
+        test1 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+#ifndef T2
+!T2:syntax,pqr-list,runtime,construct-independent,V:3.4-
+! int-expr-list no trailing comma via wait(1,2)
+      LOGICAL FUNCTION test2()
+        USE OPENACC
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: i
+        REAL(8), DIMENSION(LOOPCOUNT) :: a, b, c
+        INTEGER :: errors
+        errors = 0
+
+        SEEDDIM(1) = 1
+#       ifdef SEED
+        SEEDDIM(1) = SEED
+#       endif
+        CALL RANDOM_SEED(PUT=SEEDDIM)
+        CALL RANDOM_NUMBER(a)
+        CALL RANDOM_NUMBER(b)
+        c = 0.0D0
+
+        !$acc data copyin(a(1:LOOPCOUNT), b(1:LOOPCOUNT)) copy(c(1:LOOPCOUNT))
+          !$acc parallel present(a(1:LOOPCOUNT), b(1:LOOPCOUNT), c(1:LOOPCOUNT)) async(1)
+            !$acc loop
+            DO i = 1, LOOPCOUNT
+              c(i) = a(i) + b(i)
+            END DO
+          !$acc end parallel
+
+          !$acc parallel present(c(1:LOOPCOUNT)) async(2)
+            !$acc loop
+            DO i = 1, LOOPCOUNT
+              c(i) = c(i)
+            END DO
+          !$acc end parallel
+
+          !$acc wait(1,2)
+        !$acc end data
+
+        DO i = 1, LOOPCOUNT
+          IF (ABS(c(i) - (a(i) + b(i))) .GT. PRECISION) errors = errors + 1
+        END DO
+
+        test2 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+#ifndef T3
+!T3:syntax,pqr-list,runtime,construct-independent,V:3.4-
+! var-list non-empty via copyin(a(...))
+      LOGICAL FUNCTION test3()
+        USE OPENACC
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: i
+        REAL(8), DIMENSION(LOOPCOUNT) :: a, c
+        INTEGER :: errors
+        errors = 0
+
+        SEEDDIM(1) = 1
+#       ifdef SEED
+        SEEDDIM(1) = SEED
+#       endif
+        CALL RANDOM_SEED(PUT=SEEDDIM)
+        CALL RANDOM_NUMBER(a)
+        c = 0.0D0
+
+        !$acc data copyin(a(1:LOOPCOUNT)) copy(c(1:LOOPCOUNT))
+          !$acc parallel present(a(1:LOOPCOUNT), c(1:LOOPCOUNT))
+            !$acc loop
+            DO i = 1, LOOPCOUNT
+              c(i) = 2.0D0 * a(i)
+            END DO
+          !$acc end parallel
+        !$acc end data
+
+        DO i = 1, LOOPCOUNT
+          IF (ABS(c(i) - (2.0D0 * a(i))) .GT. PRECISION) errors = errors + 1
+        END DO
+
+        test3 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+#ifndef T4
+!T4:syntax,pqr-list,runtime,construct-independent,V:3.4-
+! var-list no trailing comma via copyin(a(...), b(...)) and present(a,b,c)
+      LOGICAL FUNCTION test4()
+        USE OPENACC
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: i
+        REAL(8), DIMENSION(LOOPCOUNT) :: a, b, c
+        INTEGER :: errors
+        errors = 0
+
+        SEEDDIM(1) = 1
+#       ifdef SEED
+        SEEDDIM(1) = SEED
+#       endif
+        CALL RANDOM_SEED(PUT=SEEDDIM)
+        CALL RANDOM_NUMBER(a)
+        CALL RANDOM_NUMBER(b)
+        c = 0.0D0
+
+        !$acc data copyin(a(1:LOOPCOUNT), b(1:LOOPCOUNT)) copy(c(1:LOOPCOUNT))
+          !$acc parallel present(a(1:LOOPCOUNT), b(1:LOOPCOUNT), c(1:LOOPCOUNT))
+            !$acc loop
+            DO i = 1, LOOPCOUNT
+              c(i) = a(i) + b(i)
+            END DO
+          !$acc end parallel
+        !$acc end data
+
+        DO i = 1, LOOPCOUNT
+          IF (ABS(c(i) - (a(i) + b(i))) .GT. PRECISION) errors = errors + 1
+        END DO
+
+        test4 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+      PROGRAM main
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: failcode, testrun
+        LOGICAL :: failed
+#ifndef T1
+        LOGICAL :: test1
+#endif
+#ifndef T2
+        LOGICAL :: test2
+#endif
+#ifndef T3
+        LOGICAL :: test3
+#endif
+#ifndef T4
+        LOGICAL :: test4
+#endif
+
+        failcode = 0
+
+#ifndef T1
+        failed = .FALSE.
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .OR. test1()
+        END DO
+        IF (failed) failcode = failcode + 2**0
+#endif
+
+#ifndef T2
+        failed = .FALSE.
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .OR. test2()
+        END DO
+        IF (failed) failcode = failcode + 2**1
+#endif
+
+#ifndef T3
+        failed = .FALSE.
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .OR. test3()
+        END DO
+        IF (failed) failcode = failcode + 2**2
+#endif
+
+#ifndef T4
+        failed = .FALSE.
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .OR. test4()
+        END DO
+        IF (failed) failcode = failcode + 2**3
+#endif
+
+        CALL EXIT(failcode)
+      END PROGRAM

--- a/Tests/acc_pqr_list.F90
+++ b/Tests/acc_pqr_list.F90
@@ -1,3 +1,14 @@
+! acc_pqr_list.F90
+! Validates correct usage of OpenACC pqr-lists in Fortran as clarified in OpenACC 3.4 Section 1.6.
+! Confirms that pqr-lists used in OpenACC directives:
+!   - contain one or more items
+!   - do not include trailing commas
+! The tests exercise valid var-list pqr-lists in data clauses (copyin, copy)
+! and valid int-expr-list pqr-lists in synchronization clauses (wait),
+! using both single-item and multi-item lists.
+! Correctness is verified at runtime by comparing device-computed results
+! with expected host values.
+
 #ifndef T1
 !T1:syntax,pqr-list,runtime,construct-independent,V:3.4-
 ! int-expr-list non-empty via wait(1)

--- a/Tests/acc_pqr_list.c
+++ b/Tests/acc_pqr_list.c
@@ -1,6 +1,6 @@
 // acc_pqr_list.c
 //
-// Feature under test (OpenACC 3.4, Section 1.6):
+// Feature under test (OpenACC 3.4, Section 1.6, Feb 2026):
 // - A pqr-list must contain at least one item.
 // - A pqr-list must not have a trailing comma.
 //

--- a/Tests/acc_pqr_list.c
+++ b/Tests/acc_pqr_list.c
@@ -1,3 +1,14 @@
+// acc_pqr_list.c
+// Validates correct usage of OpenACC pqr-lists as clarified in OpenACC 3.4 Section 1.6.
+// Confirms that both var-lists and int-expr-lists used in OpenACC clauses:
+//   - contain at least one item
+//   - do not include trailing commas
+// The tests exercise valid pqr-list forms in data clauses (copyin, copyout, present)
+// and synchronization clauses (wait) using both single-item and multi-item lists.
+// Runtime checks verify correctness of device computations to ensure the directives
+// are parsed and applied as intended by the specification.
+
+
 #include "acc_testsuite.h"
 
 #ifndef T1

--- a/Tests/acc_pqr_list.c
+++ b/Tests/acc_pqr_list.c
@@ -1,0 +1,193 @@
+#include "acc_testsuite.h"
+
+#ifndef T1
+//T1:syntax,pqr-list,runtime,construct-independent,V:3.4-
+// int-expr-list non-empty (single item) via wait(1)
+int test1(void){
+    int err = 0;
+    srand(SEED);
+
+    real_t *a = (real_t*)malloc(n * sizeof(real_t));
+    real_t *b = (real_t*)malloc(n * sizeof(real_t));
+    real_t *c = (real_t*)malloc(n * sizeof(real_t));
+    if (!a || !b || !c){
+        free(a); free(b); free(c);
+        return 1;
+    }
+
+    for (int i = 0; i < n; ++i){
+        a[i] = rand() / (real_t)(RAND_MAX / 10);
+        b[i] = rand() / (real_t)(RAND_MAX / 10);
+        c[i] = 0;
+    }
+
+    #pragma acc data copyin(a[0:n], b[0:n]) copyout(c[0:n])
+    {
+        #pragma acc parallel loop present(a[0:n], b[0:n], c[0:n]) async(1)
+        for (int i = 0; i < n; ++i){
+            c[i] = a[i] + b[i];
+        }
+
+        // Valid int-expr-list (non-empty)
+        #pragma acc wait(1)
+    }
+
+    for (int i = 0; i < n; ++i){
+        if (fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+    }
+
+    free(a); free(b); free(c);
+    return err;
+}
+#endif
+
+#ifndef T2
+//T2:syntax,pqr-list,runtime,construct-independent,V:3.4-
+// int-expr-list no trailing comma (multi-item list) via wait(1,2)
+int test2(void){
+    int err = 0;
+    srand(SEED);
+
+    real_t *a = (real_t*)malloc(n * sizeof(real_t));
+    real_t *b = (real_t*)malloc(n * sizeof(real_t));
+    real_t *c = (real_t*)malloc(n * sizeof(real_t));
+    if (!a || !b || !c){
+        free(a); free(b); free(c);
+        return 1;
+    }
+
+    for (int i = 0; i < n; ++i){
+        a[i] = rand() / (real_t)(RAND_MAX / 10);
+        b[i] = rand() / (real_t)(RAND_MAX / 10);
+        c[i] = 0;
+    }
+
+    #pragma acc data copyin(a[0:n], b[0:n]) copyout(c[0:n])
+    {
+        #pragma acc parallel loop present(a[0:n], b[0:n], c[0:n]) async(1)
+        for (int i = 0; i < n; ++i){
+            c[i] = a[i] + b[i];
+        }
+
+        // second async region to make queue 2 meaningful
+        #pragma acc parallel loop present(c[0:n]) async(2)
+        for (int i = 0; i < n; ++i){
+            c[i] = c[i];
+        }
+
+        // Valid multi-item int-expr-list with NO trailing comma
+        #pragma acc wait(1,2)
+    }
+
+    for (int i = 0; i < n; ++i){
+        if (fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+    }
+
+    free(a); free(b); free(c);
+    return err;
+}
+#endif
+
+#ifndef T3
+//T3:syntax,pqr-list,runtime,construct-independent,V:3.4-
+// var-list non-empty (single item) via copyin(a[0:n])
+int test3(void){
+    int err = 0;
+    srand(SEED);
+
+    real_t *a = (real_t*)malloc(n * sizeof(real_t));
+    real_t *c = (real_t*)malloc(n * sizeof(real_t));
+    if (!a || !c){
+        free(a); free(c);
+        return 1;
+    }
+
+    for (int i = 0; i < n; ++i){
+        a[i] = rand() / (real_t)(RAND_MAX / 10);
+        c[i] = 0;
+    }
+
+    // Valid single-item var-list (non-empty)
+    #pragma acc data copyin(a[0:n]) copyout(c[0:n])
+    {
+        #pragma acc parallel loop present(a[0:n], c[0:n])
+        for (int i = 0; i < n; ++i){
+            c[i] = a[i] * 2;
+        }
+    }
+
+    for (int i = 0; i < n; ++i){
+        if (fabs(c[i] - (a[i] * 2)) > PRECISION) err++;
+    }
+
+    free(a); free(c);
+    return err;
+}
+#endif
+
+#ifndef T4
+//T4:syntax,pqr-list,runtime,construct-independent,V:3.4-
+// var-list no trailing comma (multi-item) via copyin(a[0:n], b[0:n]) and present(a,b,c)
+int test4(void){
+    int err = 0;
+    srand(SEED);
+
+    real_t *a = (real_t*)malloc(n * sizeof(real_t));
+    real_t *b = (real_t*)malloc(n * sizeof(real_t));
+    real_t *c = (real_t*)malloc(n * sizeof(real_t));
+    if (!a || !b || !c){
+        free(a); free(b); free(c);
+        return 1;
+    }
+
+    for (int i = 0; i < n; ++i){
+        a[i] = rand() / (real_t)(RAND_MAX / 10);
+        b[i] = rand() / (real_t)(RAND_MAX / 10);
+        c[i] = 0;
+    }
+
+    // Valid multi-item var-list with NO trailing comma
+    #pragma acc data copyin(a[0:n], b[0:n]) copyout(c[0:n])
+    {
+        #pragma acc parallel loop present(a[0:n], b[0:n], c[0:n])
+        for (int i = 0; i < n; ++i){
+            c[i] = a[i] + b[i];
+        }
+    }
+
+    for (int i = 0; i < n; ++i){
+        if (fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+    }
+
+    free(a); free(b); free(c);
+    return err;
+}
+#endif
+
+int main(void){
+    int failcode = 0;
+    int failed;
+
+#ifndef T1
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test1();
+    if (failed) failcode |= (1 << 0);
+#endif
+#ifndef T2
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test2();
+    if (failed) failcode |= (1 << 1);
+#endif
+#ifndef T3
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test3();
+    if (failed) failcode |= (1 << 2);
+#endif
+#ifndef T4
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test4();
+    if (failed) failcode |= (1 << 3);
+#endif
+
+    return failcode;
+}

--- a/Tests/acc_pqr_list.c
+++ b/Tests/acc_pqr_list.c
@@ -4,18 +4,17 @@
 // - A pqr-list must contain at least one item.
 // - A pqr-list must not have a trailing comma.
 //
-// This test exercises valid pqr-list forms in:
-//   - var-lists (copyin, copyout, present)
-//   - int-expr-lists (wait)
+// Notes:
+//   T1: int-expr-list is non-empty (single-item list)
+//   T2: int-expr-list has no trailing comma (multi-item list)
+//   T3: var-list is non-empty (single-item list)
+//   T4: var-list has no trailing comma (multi-item list)
 //
-// Only spec-compliant (non-empty, no trailing comma) forms are used.
 
 
 #include "acc_testsuite.h"
 
 #ifndef T1
-//T1:syntax,pqr-list,runtime,construct-independent,V:3.4-
-// int-expr-list non-empty (single item) via wait(1)
 int test1(void){
     int err = 0;
     srand(SEED);
@@ -24,7 +23,9 @@ int test1(void){
     real_t *b = (real_t*)malloc(n * sizeof(real_t));
     real_t *c = (real_t*)malloc(n * sizeof(real_t));
     if (!a || !b || !c){
-        free(a); free(b); free(c);
+        free(a); 
+        free(b); 
+        free(c);
         return 1;
     }
 
@@ -41,22 +42,23 @@ int test1(void){
             c[i] = a[i] + b[i];
         }
 
-        // Valid int-expr-list (non-empty)
         #pragma acc wait(1)
     }
 
     for (int i = 0; i < n; ++i){
-        if (fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+        if (fabs(c[i] - (a[i] + b[i])) > PRECISION){
+            err++;
+        }
     }
 
-    free(a); free(b); free(c);
+    free(a); 
+    free(b);
+    free(c);
     return err;
 }
 #endif
 
 #ifndef T2
-//T2:syntax,pqr-list,runtime,construct-independent,V:3.4-
-// int-expr-list no trailing comma (multi-item list) via wait(1,2)
 int test2(void){
     int err = 0;
     srand(SEED);
@@ -65,7 +67,9 @@ int test2(void){
     real_t *b = (real_t*)malloc(n * sizeof(real_t));
     real_t *c = (real_t*)malloc(n * sizeof(real_t));
     if (!a || !b || !c){
-        free(a); free(b); free(c);
+        free(a); 
+        free(b); 
+        free(c);
         return 1;
     }
 
@@ -82,13 +86,11 @@ int test2(void){
             c[i] = a[i] + b[i];
         }
 
-        // second async region to make queue 2 meaningful
         #pragma acc parallel loop present(c[0:n]) async(2)
         for (int i = 0; i < n; ++i){
             c[i] = c[i];
         }
 
-        // Valid multi-item int-expr-list with NO trailing comma
         #pragma acc wait(1,2)
     }
 
@@ -96,14 +98,14 @@ int test2(void){
         if (fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
     }
 
-    free(a); free(b); free(c);
+    free(a); 
+    free(b); 
+    free(c);
     return err;
 }
 #endif
 
 #ifndef T3
-//T3:syntax,pqr-list,runtime,construct-independent,V:3.4-
-// var-list non-empty (single item) via copyin(a[0:n])
 int test3(void){
     int err = 0;
     srand(SEED);
@@ -111,7 +113,8 @@ int test3(void){
     real_t *a = (real_t*)malloc(n * sizeof(real_t));
     real_t *c = (real_t*)malloc(n * sizeof(real_t));
     if (!a || !c){
-        free(a); free(c);
+        free(a); 
+        free(c);
         return 1;
     }
 
@@ -120,7 +123,6 @@ int test3(void){
         c[i] = 0;
     }
 
-    // Valid single-item var-list (non-empty)
     #pragma acc data copyin(a[0:n]) copyout(c[0:n])
     {
         #pragma acc parallel loop present(a[0:n], c[0:n])
@@ -130,17 +132,18 @@ int test3(void){
     }
 
     for (int i = 0; i < n; ++i){
-        if (fabs(c[i] - (a[i] * 2)) > PRECISION) err++;
+        if (fabs(c[i] - (a[i] * 2)) > PRECISION){
+            err++;
+        }
     }
 
-    free(a); free(c);
+    free(a); 
+    free(c);
     return err;
 }
 #endif
 
 #ifndef T4
-//T4:syntax,pqr-list,runtime,construct-independent,V:3.4-
-// var-list no trailing comma (multi-item) via copyin(a[0:n], b[0:n]) and present(a,b,c)
 int test4(void){
     int err = 0;
     srand(SEED);
@@ -149,7 +152,9 @@ int test4(void){
     real_t *b = (real_t*)malloc(n * sizeof(real_t));
     real_t *c = (real_t*)malloc(n * sizeof(real_t));
     if (!a || !b || !c){
-        free(a); free(b); free(c);
+        free(a); 
+        free(b); 
+        free(c);
         return 1;
     }
 
@@ -159,7 +164,6 @@ int test4(void){
         c[i] = 0;
     }
 
-    // Valid multi-item var-list with NO trailing comma
     #pragma acc data copyin(a[0:n], b[0:n]) copyout(c[0:n])
     {
         #pragma acc parallel loop present(a[0:n], b[0:n], c[0:n])
@@ -169,10 +173,14 @@ int test4(void){
     }
 
     for (int i = 0; i < n; ++i){
-        if (fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+        if (fabs(c[i] - (a[i] + b[i])) > PRECISION){
+            err++;
+        }
     }
 
-    free(a); free(b); free(c);
+    free(a); 
+    free(b); 
+    free(c);
     return err;
 }
 #endif
@@ -183,23 +191,39 @@ int main(void){
 
 #ifndef T1
     failed = 0;
-    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test1();
-    if (failed) failcode |= (1 << 0);
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test1();
+    }
+    if (failed){
+        failcode |= (1 << 0);
+    }
 #endif
 #ifndef T2
     failed = 0;
-    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test2();
-    if (failed) failcode |= (1 << 1);
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test2();
+    }
+    if (failed){
+        failcode |= (1 << 1);
+    }
 #endif
 #ifndef T3
     failed = 0;
-    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test3();
-    if (failed) failcode |= (1 << 2);
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test3();
+    }
+    if (failed){
+        failcode |= (1 << 2);
+    }
 #endif
 #ifndef T4
     failed = 0;
-    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test4();
-    if (failed) failcode |= (1 << 3);
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test4();
+    }
+    if (failed){
+        failcode |= (1 << 3);
+    }
 #endif
 
     return failcode;

--- a/Tests/acc_pqr_list.c
+++ b/Tests/acc_pqr_list.c
@@ -1,12 +1,14 @@
 // acc_pqr_list.c
-// Validates correct usage of OpenACC pqr-lists as clarified in OpenACC 3.4 Section 1.6.
-// Confirms that both var-lists and int-expr-lists used in OpenACC clauses:
-//   - contain at least one item
-//   - do not include trailing commas
-// The tests exercise valid pqr-list forms in data clauses (copyin, copyout, present)
-// and synchronization clauses (wait) using both single-item and multi-item lists.
-// Runtime checks verify correctness of device computations to ensure the directives
-// are parsed and applied as intended by the specification.
+//
+// Feature under test (OpenACC 3.4, Section 1.6):
+// - A pqr-list must contain at least one item.
+// - A pqr-list must not have a trailing comma.
+//
+// This test exercises valid pqr-list forms in:
+//   - var-lists (copyin, copyout, present)
+//   - int-expr-lists (wait)
+//
+// Only spec-compliant (non-empty, no trailing comma) forms are used.
 
 
 #include "acc_testsuite.h"

--- a/Tests/acc_pqr_list.cpp
+++ b/Tests/acc_pqr_list.cpp
@@ -1,3 +1,13 @@
+// acc_pqr_list.cpp
+// Validates correct usage of OpenACC pqr-lists in C++ as clarified in OpenACC 3.4 Section 1.6.
+// Ensures that pqr-lists appearing in OpenACC clauses:
+//   - are non-empty
+//   - do not contain trailing commas
+// The tests cover both var-lists (copyin, copyout, present) and int-expr-lists (wait),
+// using single-item and multi-item lists in C++ compilation mode.
+// Device execution results are compared against expected host values to confirm
+// correct runtime behavior in addition to syntactic acceptance.
+
 #include "acc_testsuite.h"
 #include <cstdlib>
 #include <cmath>

--- a/Tests/acc_pqr_list.cpp
+++ b/Tests/acc_pqr_list.cpp
@@ -4,11 +4,12 @@
 // - A pqr-list must contain at least one item.
 // - A pqr-list must not have a trailing comma.
 //
-// This test exercises valid pqr-list forms in C++ compilation mode for:
-//   - var-lists (copyin, copyout, present)
-//   - int-expr-lists (wait)
+// Notes:
+//   T1: int-expr-list is non-empty (single-item list)
+//   T2: int-expr-list has no trailing comma (multi-item list)
+//   T3: var-list is non-empty (single-item list)
+//   T4: var-list has no trailing comma (multi-item list)
 //
-// All pqr-lists used are non-empty and contain no trailing commas.
 
 
 #include "acc_testsuite.h"
@@ -16,7 +17,6 @@
 #include <cmath>
 
 #ifndef T1
-//T1:syntax,pqr-list,runtime,construct-independent,V:3.4-
 int test1(){
     int err = 0;
     srand(SEED);
@@ -25,7 +25,9 @@ int test1(){
     real_t* b = (real_t*)malloc(n * sizeof(real_t));
     real_t* c = (real_t*)malloc(n * sizeof(real_t));
     if (!a || !b || !c){
-        free(a); free(b); free(c);
+        free(a); 
+        free(b); 
+        free(c);
         return 1;
     }
 
@@ -45,16 +47,19 @@ int test1(){
     }
 
     for (int i = 0; i < n; ++i){
-        if (fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+        if (fabs(c[i] - (a[i] + b[i])) > PRECISION){
+            err++;
+        }
     }
 
-    free(a); free(b); free(c);
+    free(a); 
+    free(b); 
+    free(c);
     return err;
 }
 #endif
 
 #ifndef T2
-//T2:syntax,pqr-list,runtime,construct-independent,V:3.4-
 int test2(){
     int err = 0;
     srand(SEED);
@@ -63,7 +68,9 @@ int test2(){
     real_t* b = (real_t*)malloc(n * sizeof(real_t));
     real_t* c = (real_t*)malloc(n * sizeof(real_t));
     if (!a || !b || !c){
-        free(a); free(b); free(c);
+        free(a); 
+        free(b); 
+        free(c);
         return 1;
     }
 
@@ -87,16 +94,19 @@ int test2(){
     }
 
     for (int i = 0; i < n; ++i){
-        if (fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+        if (fabs(c[i] - (a[i] + b[i])) > PRECISION){
+            err++;
+        }
     }
 
-    free(a); free(b); free(c);
+    free(a); 
+    free(b); 
+    free(c);
     return err;
 }
 #endif
 
 #ifndef T3
-//T3:syntax,pqr-list,runtime,construct-independent,V:3.4-
 int test3(){
     int err = 0;
     srand(SEED);
@@ -104,7 +114,8 @@ int test3(){
     real_t* a = (real_t*)malloc(n * sizeof(real_t));
     real_t* c = (real_t*)malloc(n * sizeof(real_t));
     if (!a || !c){
-        free(a); free(c);
+        free(a); 
+        free(c);
         return 1;
     }
 
@@ -122,16 +133,18 @@ int test3(){
     }
 
     for (int i = 0; i < n; ++i){
-        if (fabs(c[i] - (a[i] * 2)) > PRECISION) err++;
+        if (fabs(c[i] - (a[i] * 2)) > PRECISION){
+            err++;
+        }
     }
 
-    free(a); free(c);
+    free(a); 
+    free(c);
     return err;
 }
 #endif
 
 #ifndef T4
-//T4:syntax,pqr-list,runtime,construct-independent,V:3.4-
 int test4(){
     int err = 0;
     srand(SEED);
@@ -140,7 +153,9 @@ int test4(){
     real_t* b = (real_t*)malloc(n * sizeof(real_t));
     real_t* c = (real_t*)malloc(n * sizeof(real_t));
     if (!a || !b || !c){
-        free(a); free(b); free(c);
+        free(a); 
+        free(b); 
+        free(c);
         return 1;
     }
 
@@ -159,10 +174,14 @@ int test4(){
     }
 
     for (int i = 0; i < n; ++i){
-        if (fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+        if (fabs(c[i] - (a[i] + b[i])) > PRECISION){
+            err++;
+        }
     }
 
-    free(a); free(b); free(c);
+    free(a); 
+    free(b); 
+    free(c);
     return err;
 }
 #endif
@@ -173,23 +192,39 @@ int main(){
 
 #ifndef T1
     failed = 0;
-    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test1();
-    if (failed) failcode |= (1 << 0);
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test1();
+    }
+    if (failed){
+        failcode |= (1 << 0);
+    }
 #endif
 #ifndef T2
     failed = 0;
-    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test2();
-    if (failed) failcode |= (1 << 1);
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test2();
+    }
+    if (failed){
+        failcode |= (1 << 1);
+    }
 #endif
 #ifndef T3
     failed = 0;
-    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test3();
-    if (failed) failcode |= (1 << 2);
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test3();
+    }
+    if (failed){
+        failcode |= (1 << 2);
+    }
 #endif
 #ifndef T4
     failed = 0;
-    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test4();
-    if (failed) failcode |= (1 << 3);
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test4();
+    }
+    if (failed){
+        failcode |= (1 << 3);
+    }
 #endif
 
     return failcode;

--- a/Tests/acc_pqr_list.cpp
+++ b/Tests/acc_pqr_list.cpp
@@ -1,12 +1,15 @@
 // acc_pqr_list.cpp
-// Validates correct usage of OpenACC pqr-lists in C++ as clarified in OpenACC 3.4 Section 1.6.
-// Ensures that pqr-lists appearing in OpenACC clauses:
-//   - are non-empty
-//   - do not contain trailing commas
-// The tests cover both var-lists (copyin, copyout, present) and int-expr-lists (wait),
-// using single-item and multi-item lists in C++ compilation mode.
-// Device execution results are compared against expected host values to confirm
-// correct runtime behavior in addition to syntactic acceptance.
+//
+// Feature under test (OpenACC 3.4, Section 1.6):
+// - A pqr-list must contain at least one item.
+// - A pqr-list must not have a trailing comma.
+//
+// This test exercises valid pqr-list forms in C++ compilation mode for:
+//   - var-lists (copyin, copyout, present)
+//   - int-expr-lists (wait)
+//
+// All pqr-lists used are non-empty and contain no trailing commas.
+
 
 #include "acc_testsuite.h"
 #include <cstdlib>

--- a/Tests/acc_pqr_list.cpp
+++ b/Tests/acc_pqr_list.cpp
@@ -1,6 +1,6 @@
 // acc_pqr_list.cpp
 //
-// Feature under test (OpenACC 3.4, Section 1.6):
+// Feature under test (OpenACC 3.4, Section 1.6, Feb 2026):
 // - A pqr-list must contain at least one item.
 // - A pqr-list must not have a trailing comma.
 //

--- a/Tests/acc_pqr_list.cpp
+++ b/Tests/acc_pqr_list.cpp
@@ -1,0 +1,183 @@
+#include "acc_testsuite.h"
+#include <cstdlib>
+#include <cmath>
+
+#ifndef T1
+//T1:syntax,pqr-list,runtime,construct-independent,V:3.4-
+int test1(){
+    int err = 0;
+    srand(SEED);
+
+    real_t* a = (real_t*)malloc(n * sizeof(real_t));
+    real_t* b = (real_t*)malloc(n * sizeof(real_t));
+    real_t* c = (real_t*)malloc(n * sizeof(real_t));
+    if (!a || !b || !c){
+        free(a); free(b); free(c);
+        return 1;
+    }
+
+    for (int i = 0; i < n; ++i){
+        a[i] = rand() / (real_t)(RAND_MAX / 10);
+        b[i] = rand() / (real_t)(RAND_MAX / 10);
+        c[i] = 0;
+    }
+
+    #pragma acc data copyin(a[0:n], b[0:n]) copyout(c[0:n])
+    {
+        #pragma acc parallel loop present(a[0:n], b[0:n], c[0:n]) async(1)
+        for (int i = 0; i < n; ++i){
+            c[i] = a[i] + b[i];
+        }
+        #pragma acc wait(1)
+    }
+
+    for (int i = 0; i < n; ++i){
+        if (fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+    }
+
+    free(a); free(b); free(c);
+    return err;
+}
+#endif
+
+#ifndef T2
+//T2:syntax,pqr-list,runtime,construct-independent,V:3.4-
+int test2(){
+    int err = 0;
+    srand(SEED);
+
+    real_t* a = (real_t*)malloc(n * sizeof(real_t));
+    real_t* b = (real_t*)malloc(n * sizeof(real_t));
+    real_t* c = (real_t*)malloc(n * sizeof(real_t));
+    if (!a || !b || !c){
+        free(a); free(b); free(c);
+        return 1;
+    }
+
+    for (int i = 0; i < n; ++i){
+        a[i] = rand() / (real_t)(RAND_MAX / 10);
+        b[i] = rand() / (real_t)(RAND_MAX / 10);
+        c[i] = 0;
+    }
+
+    #pragma acc data copyin(a[0:n], b[0:n]) copyout(c[0:n])
+    {
+        #pragma acc parallel loop present(a[0:n], b[0:n], c[0:n]) async(1)
+        for (int i = 0; i < n; ++i){
+            c[i] = a[i] + b[i];
+        }
+        #pragma acc parallel loop present(c[0:n]) async(2)
+        for (int i = 0; i < n; ++i){
+            c[i] = c[i];
+        }
+        #pragma acc wait(1,2)
+    }
+
+    for (int i = 0; i < n; ++i){
+        if (fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+    }
+
+    free(a); free(b); free(c);
+    return err;
+}
+#endif
+
+#ifndef T3
+//T3:syntax,pqr-list,runtime,construct-independent,V:3.4-
+int test3(){
+    int err = 0;
+    srand(SEED);
+
+    real_t* a = (real_t*)malloc(n * sizeof(real_t));
+    real_t* c = (real_t*)malloc(n * sizeof(real_t));
+    if (!a || !c){
+        free(a); free(c);
+        return 1;
+    }
+
+    for (int i = 0; i < n; ++i){
+        a[i] = rand() / (real_t)(RAND_MAX / 10);
+        c[i] = 0;
+    }
+
+    #pragma acc data copyin(a[0:n]) copyout(c[0:n])
+    {
+        #pragma acc parallel loop present(a[0:n], c[0:n])
+        for (int i = 0; i < n; ++i){
+            c[i] = a[i] * 2;
+        }
+    }
+
+    for (int i = 0; i < n; ++i){
+        if (fabs(c[i] - (a[i] * 2)) > PRECISION) err++;
+    }
+
+    free(a); free(c);
+    return err;
+}
+#endif
+
+#ifndef T4
+//T4:syntax,pqr-list,runtime,construct-independent,V:3.4-
+int test4(){
+    int err = 0;
+    srand(SEED);
+
+    real_t* a = (real_t*)malloc(n * sizeof(real_t));
+    real_t* b = (real_t*)malloc(n * sizeof(real_t));
+    real_t* c = (real_t*)malloc(n * sizeof(real_t));
+    if (!a || !b || !c){
+        free(a); free(b); free(c);
+        return 1;
+    }
+
+    for (int i = 0; i < n; ++i){
+        a[i] = rand() / (real_t)(RAND_MAX / 10);
+        b[i] = rand() / (real_t)(RAND_MAX / 10);
+        c[i] = 0;
+    }
+
+    #pragma acc data copyin(a[0:n], b[0:n]) copyout(c[0:n])
+    {
+        #pragma acc parallel loop present(a[0:n], b[0:n], c[0:n])
+        for (int i = 0; i < n; ++i){
+            c[i] = a[i] + b[i];
+        }
+    }
+
+    for (int i = 0; i < n; ++i){
+        if (fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+    }
+
+    free(a); free(b); free(c);
+    return err;
+}
+#endif
+
+int main(){
+    int failcode = 0;
+    int failed;
+
+#ifndef T1
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test1();
+    if (failed) failcode |= (1 << 0);
+#endif
+#ifndef T2
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test2();
+    if (failed) failcode |= (1 << 1);
+#endif
+#ifndef T3
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test3();
+    if (failed) failcode |= (1 << 2);
+#endif
+#ifndef T4
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test4();
+    if (failed) failcode |= (1 << 3);
+#endif
+
+    return failcode;
+}


### PR DESCRIPTION
Test Purpose:
These files validate the OpenACC 3.4 clarification about pqr-lists (Section 1.6): a pqr-list must be a comma-separated list with at least one item, and it must not contain a trailing comma.

These tests demonstrate accepted pqr-list forms in both contexts where pqr-lists appear:
•int-expr-list: wait( … )
•var-list: copyin( … ) (and matching present( … ) usage)

Each language file (C, C++, Fortran) contains four runtime tests (T1–T4) that validate correct compilation and execution of legal pqr-lists:
        T1 — int-expr-list is non-empty (single-item list)
•Uses wait(1) where the list is 1
•Demonstrates int-expr-list contains at least one item

        T2 — int-expr-list has no trailing comma (multi-item list)
•Uses wait(1,2)
•Demonstrates multi-item int-expr-list with proper commas between items and no trailing comma

        T3 — var-list is non-empty (single-item list)
•Uses a data clause like copyin(a[0:n]) (or Fortran slice)
•Demonstrates var-list contains at least one item

        T4 — var-list has no trailing comma (multi-item list)
•Uses a data clause like copyin(a[0:n], b[0:n]) and/or present(a,b,c)
•Demonstrates multi-item var-list with proper commas between items and no trailing comma

**How the test verifies correctness (runtime):**
Each test performs a simple vector computation on the device and verifies results on the host using the suite tolerance (PRECISION). Each file’s main returns a bitmask failcode consistent with the testsuite (bit0–bit3 correspond to T1–T4). A return code of 0 indicates all enabled tests passed.

**Files**
•acc_pqr_list.c
•acc_pqr_list.cpp
•acc_pqr_list.F90

**Compiler Versions**
NVC:  25.5.0
GCC: 15.2.0
CRAY: 18.0.0