### PR TITLE
Add tests for clarified if(condition) semantics and condition forms

### DIFF
--- a/Tests/acc_if_condition.F90
+++ b/Tests/acc_if_condition.F90
@@ -1,0 +1,244 @@
+! acc_if_condition.F90
+! Fortran conditions must be LOGICAL.
+
+#ifndef T1
+!T1:syntax,if-clause,runtime,enter-data,V:3.4-
+      LOGICAL FUNCTION test1()
+        USE OPENACC
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: i, errors
+        REAL(8), DIMENSION(LOOPCOUNT) :: a
+        LOGICAL :: present
+
+        errors = 0
+        DO i=1, LOOPCOUNT
+          a(i) = DBLE(i)
+        END DO
+
+        !$acc enter data copyin(a(1:LOOPCOUNT)) if(.FALSE.)
+        present = acc_is_present(a)
+        IF (present) errors = errors + 1
+
+        IF (present) THEN
+          !$acc exit data delete(a(1:LOOPCOUNT)) if(.TRUE.)
+        END IF
+        test1 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+#ifndef T2
+!T2:syntax,if-clause,runtime,enter-data,V:3.4-
+      LOGICAL FUNCTION test2()
+        USE OPENACC
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: i, errors
+        REAL(8), DIMENSION(LOOPCOUNT) :: a
+        LOGICAL :: present
+
+        errors = 0
+        DO i=1, LOOPCOUNT
+          a(i) = DBLE(i)
+        END DO
+
+        !$acc enter data copyin(a(1:LOOPCOUNT)) if(.TRUE.)
+        present = acc_is_present(a)
+        IF (.NOT. present) errors = errors + 1
+
+        !$acc exit data delete(a(1:LOOPCOUNT)) if(.TRUE.)
+        test2 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+#ifndef T3
+!T3:syntax,if-clause,runtime,exit-data,V:3.4-
+      LOGICAL FUNCTION test3()
+        USE OPENACC
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: i, errors
+        REAL(8), DIMENSION(LOOPCOUNT) :: a
+        LOGICAL :: present
+
+        errors = 0
+        DO i=1, LOOPCOUNT
+          a(i) = DBLE(i)
+        END DO
+
+        !$acc enter data copyin(a(1:LOOPCOUNT)) if(.TRUE.)
+        present = acc_is_present(a)
+        IF (.NOT. present) errors = errors + 1
+
+        !$acc exit data delete(a(1:LOOPCOUNT)) if(.FALSE.)
+        present = acc_is_present(a)
+        IF (.NOT. present) errors = errors + 1
+
+        !$acc exit data delete(a(1:LOOPCOUNT)) if(.TRUE.)
+        test3 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+#ifndef T4
+!T4:syntax,if-clause,runtime,exit-data,V:3.4-
+      LOGICAL FUNCTION test4()
+        USE OPENACC
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: i, errors
+        REAL(8), DIMENSION(LOOPCOUNT) :: a
+        LOGICAL :: present
+
+        errors = 0
+        DO i=1, LOOPCOUNT
+          a(i) = DBLE(i)
+        END DO
+
+        !$acc enter data copyin(a(1:LOOPCOUNT)) if(.TRUE.)
+        present = acc_is_present(a)
+        IF (.NOT. present) errors = errors + 1
+
+        !$acc exit data delete(a(1:LOOPCOUNT)) if(.TRUE.)
+        present = acc_is_present(a)
+        IF (present) errors = errors + 1
+
+        test4 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+#ifndef T5
+!T5:syntax,if-clause,runtime,compute,V:3.4-
+! logical variable condition
+      LOGICAL FUNCTION test5()
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: i, errors
+        REAL(8), DIMENSION(LOOPCOUNT) :: a, c
+        LOGICAL :: cond
+
+        errors = 0
+        cond = .TRUE.
+
+        CALL RANDOM_NUMBER(a)
+        c = 0.0D0
+
+        !$acc data copyin(a(1:LOOPCOUNT)) copy(c(1:LOOPCOUNT))
+          !$acc parallel loop present(a(1:LOOPCOUNT), c(1:LOOPCOUNT)) if(cond)
+          DO i=1, LOOPCOUNT
+            c(i) = 2.0D0 * a(i)
+          END DO
+          !$acc end parallel loop
+        !$acc end data
+
+        DO i=1, LOOPCOUNT
+          IF (ABS(c(i) - 2.0D0*a(i)) .GT. PRECISION) errors = errors + 1
+        END DO
+
+        test5 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+#ifndef T6
+!T6:syntax,if-clause,runtime,compute,V:3.4-
+! logical expression condition
+      LOGICAL FUNCTION test6()
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: i, errors
+        REAL(8), DIMENSION(LOOPCOUNT) :: a, c
+        LOGICAL :: cond
+
+        errors = 0
+        cond = .TRUE.
+
+        CALL RANDOM_NUMBER(a)
+        c = 0.0D0
+
+        !$acc data copyin(a(1:LOOPCOUNT)) copy(c(1:LOOPCOUNT))
+          !$acc parallel loop present(a(1:LOOPCOUNT), c(1:LOOPCOUNT)) &
+          !$acc& if( (LOOPCOUNT .GT. 0) .AND. cond )
+          DO i=1, LOOPCOUNT
+            c(i) = a(i) + 1.0D0
+          END DO
+          !$acc end parallel loop
+        !$acc end data
+
+        DO i=1, LOOPCOUNT
+          IF (ABS(c(i) - (a(i)+1.0D0)) .GT. PRECISION) errors = errors + 1
+        END DO
+
+        test6 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+      PROGRAM main
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: failcode, testrun
+        LOGICAL :: failed
+#ifndef T1
+        LOGICAL :: test1
+#endif
+#ifndef T2
+        LOGICAL :: test2
+#endif
+#ifndef T3
+        LOGICAL :: test3
+#endif
+#ifndef T4
+        LOGICAL :: test4
+#endif
+#ifndef T5
+        LOGICAL :: test5
+#endif
+#ifndef T6
+        LOGICAL :: test6
+#endif
+
+        failcode = 0
+
+#ifndef T1
+        failed = .FALSE.
+        DO testrun=1, NUM_TEST_CALLS
+          failed = failed .OR. test1()
+        END DO
+        IF (failed) failcode = failcode + 2**0
+#endif
+#ifndef T2
+        failed = .FALSE.
+        DO testrun=1, NUM_TEST_CALLS
+          failed = failed .OR. test2()
+        END DO
+        IF (failed) failcode = failcode + 2**1
+#endif
+#ifndef T3
+        failed = .FALSE.
+        DO testrun=1, NUM_TEST_CALLS
+          failed = failed .OR. test3()
+        END DO
+        IF (failed) failcode = failcode + 2**2
+#endif
+#ifndef T4
+        failed = .FALSE.
+        DO testrun=1, NUM_TEST_CALLS
+          failed = failed .OR. test4()
+        END DO
+        IF (failed) failcode = failcode + 2**3
+#endif
+#ifndef T5
+        failed = .FALSE.
+        DO testrun=1, NUM_TEST_CALLS
+          failed = failed .OR. test5()
+        END DO
+        IF (failed) failcode = failcode + 2**4
+#endif
+#ifndef T6
+        failed = .FALSE.
+        DO testrun=1, NUM_TEST_CALLS
+          failed = failed .OR. test6()
+        END DO
+        IF (failed) failcode = failcode + 2**5
+#endif
+
+        CALL EXIT(failcode)
+      END PROGRAM

--- a/Tests/acc_if_condition.F90
+++ b/Tests/acc_if_condition.F90
@@ -28,7 +28,9 @@
 
         !$acc enter data copyin(a(1:LOOPCOUNT)) if(.FALSE.)
         present = acc_is_present(a)
-        IF (present) errors = errors + 1
+        IF (present) THEN
+          errors = errors + 1
+        END IF
 
         IF (present) THEN
           !$acc exit data delete(a(1:LOOPCOUNT)) if(.TRUE.)
@@ -54,7 +56,9 @@
 
         !$acc enter data copyin(a(1:LOOPCOUNT)) if(.TRUE.)
         present = acc_is_present(a)
-        IF (.NOT. present) errors = errors + 1
+        IF (.NOT. present) THEN
+          errors = errors + 1
+        END IF
 
         !$acc exit data delete(a(1:LOOPCOUNT)) if(.TRUE.)
         test2 = (errors .NE. 0)
@@ -78,11 +82,15 @@
 
         !$acc enter data copyin(a(1:LOOPCOUNT)) if(.TRUE.)
         present = acc_is_present(a)
-        IF (.NOT. present) errors = errors + 1
+        IF (.NOT. present) THEN
+          errors = errors + 1
+        END IF
 
         !$acc exit data delete(a(1:LOOPCOUNT)) if(.FALSE.)
         present = acc_is_present(a)
-        IF (.NOT. present) errors = errors + 1
+        IF (.NOT. present) THEN
+          errors = errors + 1
+        END IF
 
         !$acc exit data delete(a(1:LOOPCOUNT)) if(.TRUE.)
         test3 = (errors .NE. 0)
@@ -106,11 +114,15 @@
 
         !$acc enter data copyin(a(1:LOOPCOUNT)) if(.TRUE.)
         present = acc_is_present(a)
-        IF (.NOT. present) errors = errors + 1
+        IF (.NOT. present) THEN
+          errors = errors + 1
+        END IF
 
         !$acc exit data delete(a(1:LOOPCOUNT)) if(.TRUE.)
         present = acc_is_present(a)
-        IF (present) errors = errors + 1
+        IF (present) THEN
+          errors = errors + 1
+        END IF
 
         test4 = (errors .NE. 0)
       END FUNCTION
@@ -141,7 +153,9 @@
         !$acc end data
 
         DO i=1, LOOPCOUNT
-          IF (ABS(c(i) - 2.0D0*a(i)) .GT. PRECISION) errors = errors + 1
+          IF (ABS(c(i) - 2.0D0*a(i)) .GT. PRECISION) THEN
+            errors = errors + 1
+          END IF
         END DO
 
         test5 = (errors .NE. 0)
@@ -174,7 +188,9 @@
         !$acc end data
 
         DO i=1, LOOPCOUNT
-          IF (ABS(c(i) - (a(i)+1.0D0)) .GT. PRECISION) errors = errors + 1
+          IF (ABS(c(i) - (a(i)+1.0D0)) .GT. PRECISION) THEN
+            errors = errors + 1
+          END IF
         END DO
 
         test6 = (errors .NE. 0)
@@ -212,42 +228,54 @@
         DO testrun=1, NUM_TEST_CALLS
           failed = failed .OR. test1()
         END DO
-        IF (failed) failcode = failcode + 2**0
+        IF (failed) THEN
+          failcode = failcode + 2**0
+        END IF
 #endif
 #ifndef T2
         failed = .FALSE.
         DO testrun=1, NUM_TEST_CALLS
           failed = failed .OR. test2()
         END DO
-        IF (failed) failcode = failcode + 2**1
+        IF (failed) THEN
+          failcode = failcode + 2**1
+        END IF
 #endif
 #ifndef T3
         failed = .FALSE.
         DO testrun=1, NUM_TEST_CALLS
           failed = failed .OR. test3()
         END DO
-        IF (failed) failcode = failcode + 2**2
+        IF (failed) THEN
+          failcode = failcode + 2**2
+        END IF
 #endif
 #ifndef T4
         failed = .FALSE.
         DO testrun=1, NUM_TEST_CALLS
           failed = failed .OR. test4()
         END DO
-        IF (failed) failcode = failcode + 2**3
+        IF (failed) THEN
+          failcode = failcode + 2**3
+        END IF
 #endif
 #ifndef T5
         failed = .FALSE.
         DO testrun=1, NUM_TEST_CALLS
           failed = failed .OR. test5()
         END DO
-        IF (failed) failcode = failcode + 2**4
+        IF (failed) THEN
+          failcode = failcode + 2**4
+        END IF
 #endif
 #ifndef T6
         failed = .FALSE.
         DO testrun=1, NUM_TEST_CALLS
           failed = failed .OR. test6()
         END DO
-        IF (failed) failcode = failcode + 2**5
+        IF (failed) THEN
+          failcode = failcode + 2**5
+        END IF
 #endif
 
         CALL EXIT(failcode)

--- a/Tests/acc_if_condition.F90
+++ b/Tests/acc_if_condition.F90
@@ -1,19 +1,13 @@
 ! acc_if_condition.F90
-! Validates OpenACC 3.4’s clarified definition of “condition” when used as an argument to the if clause,
-! and verifies that if(condition) correctly gates directive execution (OpenACC 3.4, Section 1.6).
 !
-! Test strategy:
-! 1) Behavior-verifiable data-directive gating (T1–T4):
-!    Uses enter data / exit data with if(.TRUE./.FALSE.) and checks device presence via acc_is_present.
-!    This directly verifies correct gating behavior for data directives in Fortran.
+! Feature under test (OpenACC 3.4, Section 1.6, Feb 2026):
+! - Clarified definition of "condition" when used as an argument to the if clause.
+! - In Fortran, the if clause argument must be a LOGICAL expression.
+! - The if clause must correctly gate execution of data and compute directives.
 !
-! 2) Condition-form coverage for compute constructs under Fortran rules (T5–T6):
-!    Fortran conditions must be LOGICAL. These tests confirm that OpenACC accepts valid Fortran LOGICAL
-!    conditions in if(...), including:
-!      - LOGICAL variable condition (T5)
-!      - LOGICAL expression condition (T6)
-!    Each compute test performs a simple computation and verifies results on the host.
-!
+! Notes:
+! - T1–T4 verify runtime gating behavior for enter data / exit data.
+! - T5–T6 verify valid Fortran LOGICAL variable and expression forms.
 
 ! Fortran conditions must be LOGICAL.
 

--- a/Tests/acc_if_condition.F90
+++ b/Tests/acc_if_condition.F90
@@ -1,4 +1,20 @@
 ! acc_if_condition.F90
+! Validates OpenACC 3.4’s clarified definition of “condition” when used as an argument to the if clause,
+! and verifies that if(condition) correctly gates directive execution (OpenACC 3.4, Section 1.6).
+!
+! Test strategy:
+! 1) Behavior-verifiable data-directive gating (T1–T4):
+!    Uses enter data / exit data with if(.TRUE./.FALSE.) and checks device presence via acc_is_present.
+!    This directly verifies correct gating behavior for data directives in Fortran.
+!
+! 2) Condition-form coverage for compute constructs under Fortran rules (T5–T6):
+!    Fortran conditions must be LOGICAL. These tests confirm that OpenACC accepts valid Fortran LOGICAL
+!    conditions in if(...), including:
+!      - LOGICAL variable condition (T5)
+!      - LOGICAL expression condition (T6)
+!    Each compute test performs a simple computation and verifies results on the host.
+!
+
 ! Fortran conditions must be LOGICAL.
 
 #ifndef T1

--- a/Tests/acc_if_condition.c
+++ b/Tests/acc_if_condition.c
@@ -1,19 +1,14 @@
 // acc_if_condition.c
-// Validates OpenACC 3.4’s clarified definition of “condition” when used as an argument to the if clause,
-// and verifies that if(condition) correctly gates directive execution (OpenACC 3.4, Section 1.6).
 //
-// Test strategy:
-// 1) Behavior-verifiable data-directive gating (T1–T4):
-//    Uses enter data / exit data with if(true/false) and checks device presence via acc_is_present.
-//    This directly proves that the runtime treats if(false) as a no-op and if(true) as executing the directive.
+// Feature under test (OpenACC 3.4, Section 1.6, Feb 2026):
+// - Clarified definition of "condition" when used as an argument to the if clause.
+// - The if(condition) clause must accept any valid C scalar condition expression.
+// - The if clause must correctly gate execution of data and compute directives.
 //
-// 2) Condition-form coverage for compute constructs (T5–T7):
-//    Confirms the compiler accepts the full set of C-valid “condition” forms in if(...):
-//      - integer scalar expression (T5)
-//      - floating-point scalar condition (T6)  (nonzero => true in C)
-//      - pointer scalar condition (T7)         (non-NULL => true in C)
-//    Each compute test performs a simple device computation and verifies results on the host.
-//
+// Notes:
+// - T1–T4 verify runtime gating behavior for enter data / exit data.
+// - T5–T7 verify valid C condition forms (integer, floating-point, pointer).
+
 
 #include "acc_testsuite.h"
 #include <openacc.h>

--- a/Tests/acc_if_condition.c
+++ b/Tests/acc_if_condition.c
@@ -1,0 +1,194 @@
+// acc_if_condition.c
+#include "acc_testsuite.h"
+#include <openacc.h>
+#include <stdlib.h>
+#include <math.h>
+#include <stddef.h>
+
+#ifndef T1
+//T1:syntax,if-clause,runtime,enter-data,V:3.4-
+// enter data if(0) => must be NO-OP (not present)
+int test1(void){
+    int err = 0;
+    real_t *a = (real_t*)malloc(n * sizeof(real_t));
+    if (!a) return 1;
+    for (int i = 0; i < n; ++i) a[i] = (real_t)i;
+
+    #pragma acc enter data copyin(a[0:n]) if(0)
+
+    if (acc_is_present(a, (size_t)n * sizeof(real_t))) err++;
+
+    #pragma acc exit data delete(a[0:n]) if(1)
+    free(a);
+    return err;
+}
+#endif
+
+#ifndef T2
+//T2:syntax,if-clause,runtime,enter-data,V:3.4-
+// enter data if(1) => must happen (present)
+int test2(void){
+    int err = 0;
+    real_t *a = (real_t*)malloc(n * sizeof(real_t));
+    if (!a) return 1;
+    for (int i = 0; i < n; ++i) a[i] = (real_t)i;
+
+    #pragma acc enter data copyin(a[0:n]) if(1)
+
+    if (!acc_is_present(a, (size_t)n * sizeof(real_t))) err++;
+
+    #pragma acc exit data delete(a[0:n]) if(1)
+    free(a);
+    return err;
+}
+#endif
+
+#ifndef T3
+//T3:syntax,if-clause,runtime,exit-data,V:3.4-
+// exit data delete if(0) => must be NO-OP (still present)
+int test3(void){
+    int err = 0;
+    real_t *a = (real_t*)malloc(n * sizeof(real_t));
+    if (!a) return 1;
+    for (int i = 0; i < n; ++i) a[i] = (real_t)i;
+
+    #pragma acc enter data copyin(a[0:n]) if(1)
+    if (!acc_is_present(a, (size_t)n * sizeof(real_t))) err++;
+
+    #pragma acc exit data delete(a[0:n]) if(0)
+    if (!acc_is_present(a, (size_t)n * sizeof(real_t))) err++;
+
+    #pragma acc exit data delete(a[0:n]) if(1)
+    free(a);
+    return err;
+}
+#endif
+
+#ifndef T4
+//T4:syntax,if-clause,runtime,exit-data,V:3.4-
+// exit data delete if(1) => must delete (not present)
+int test4(void){
+    int err = 0;
+    real_t *a = (real_t*)malloc(n * sizeof(real_t));
+    if (!a) return 1;
+    for (int i = 0; i < n; ++i) a[i] = (real_t)i;
+
+    #pragma acc enter data copyin(a[0:n]) if(1)
+    if (!acc_is_present(a, (size_t)n * sizeof(real_t))) err++;
+
+    #pragma acc exit data delete(a[0:n]) if(1)
+    if (acc_is_present(a, (size_t)n * sizeof(real_t))) err++;
+
+    free(a);
+    return err;
+}
+#endif
+
+// ---------- compute-side condition FORM coverage (C rules: any scalar) ----------
+
+#ifndef T5
+//T5:syntax,if-clause,runtime,compute,V:3.4-
+// int scalar expression as condition
+int test5(void){
+    int err = 0;
+    srand(SEED);
+    real_t *a = (real_t*)malloc(n*sizeof(real_t));
+    real_t *b = (real_t*)malloc(n*sizeof(real_t));
+    real_t *c = (real_t*)malloc(n*sizeof(real_t));
+    if (!a || !b || !c){ free(a); free(b); free(c); return 1; }
+
+    for (int i=0;i<n;++i){ a[i]=rand()/(real_t)(RAND_MAX/10); b[i]=rand()/(real_t)(RAND_MAX/10); c[i]=0; }
+
+    int cond_int = (n > 0); // runtime scalar int condition
+
+    #pragma acc data copyin(a[0:n],b[0:n]) copyout(c[0:n])
+    {
+        #pragma acc parallel loop present(a[0:n],b[0:n],c[0:n]) if(cond_int)
+        for (int i=0;i<n;++i) c[i]=a[i]+b[i];
+    }
+
+    for (int i=0;i<n;++i) if (fabs(c[i]-(a[i]+b[i]))>PRECISION) err++;
+    free(a); free(b); free(c);
+    return err;
+}
+#endif
+
+#ifndef T6
+//T6:syntax,if-clause,runtime,compute,V:3.4-
+// floating-point scalar as condition (C: nonzero => true)
+int test6(void){
+    int err = 0;
+    srand(SEED);
+    real_t *a = (real_t*)malloc(n*sizeof(real_t));
+    real_t *c = (real_t*)malloc(n*sizeof(real_t));
+    if (!a || !c){ free(a); free(c); return 1; }
+
+    for (int i=0;i<n;++i){ a[i]=rand()/(real_t)(RAND_MAX/10); c[i]=0; }
+
+    real_t cond_real = (real_t)1.0; // nonzero scalar => true in C
+
+    #pragma acc data copyin(a[0:n]) copyout(c[0:n])
+    {
+        #pragma acc parallel loop present(a[0:n],c[0:n]) if(cond_real)
+        for (int i=0;i<n;++i) c[i]=a[i]*(real_t)2.0;
+    }
+
+    for (int i=0;i<n;++i) if (fabs(c[i]-(a[i]*(real_t)2.0))>PRECISION) err++;
+    free(a); free(c);
+    return err;
+}
+#endif
+
+#ifndef T7
+//T7:syntax,if-clause,runtime,compute,V:3.4-
+// pointer scalar as condition (C: non-NULL => true)
+int test7(void){
+    int err = 0;
+    srand(SEED);
+    real_t *a = (real_t*)malloc(n*sizeof(real_t));
+    real_t *c = (real_t*)malloc(n*sizeof(real_t));
+    if (!a || !c){ free(a); free(c); return 1; }
+
+    for (int i=0;i<n;++i){ a[i]=rand()/(real_t)(RAND_MAX/10); c[i]=0; }
+
+    void* cond_ptr = (void*)a; // non-NULL pointer => true in C
+
+    #pragma acc data copyin(a[0:n]) copyout(c[0:n])
+    {
+        #pragma acc parallel loop present(a[0:n],c[0:n]) if(cond_ptr)
+        for (int i=0;i<n;++i) c[i]=a[i]+(real_t)1.0;
+    }
+
+    for (int i=0;i<n;++i) if (fabs(c[i]-(a[i]+(real_t)1.0))>PRECISION) err++;
+    free(a); free(c);
+    return err;
+}
+#endif
+
+int main(void){
+    int failcode = 0, failed;
+
+#ifndef T1
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test1(); if(failed) failcode|=(1<<0);
+#endif
+#ifndef T2
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test2(); if(failed) failcode|=(1<<1);
+#endif
+#ifndef T3
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test3(); if(failed) failcode|=(1<<2);
+#endif
+#ifndef T4
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test4(); if(failed) failcode|=(1<<3);
+#endif
+#ifndef T5
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test5(); if(failed) failcode|=(1<<4);
+#endif
+#ifndef T6
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test6(); if(failed) failcode|=(1<<5);
+#endif
+#ifndef T7
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test7(); if(failed) failcode|=(1<<6);
+#endif
+
+    return failcode;
+}

--- a/Tests/acc_if_condition.c
+++ b/Tests/acc_if_condition.c
@@ -262,25 +262,67 @@ int main(void){
     int failcode = 0, failed;
 
 #ifndef T1
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test1(); if(failed) failcode|=(1<<0);
+    failed=0; 
+    for(int i=0;i<NUM_TEST_CALLS;++i){
+        failed+=test1();
+    }
+    if(failed){
+        failcode|=(1<<0);
+    }
 #endif
 #ifndef T2
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test2(); if(failed) failcode|=(1<<1);
+    failed=0; 
+    for(int i=0;i<NUM_TEST_CALLS;++i){
+        failed+=test2();
+    }
+    if(failed){
+        failcode|=(1<<1);
+    }
 #endif
 #ifndef T3
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test3(); if(failed) failcode|=(1<<2);
+    failed=0;
+    for(int i=0;i<NUM_TEST_CALLS;++i){
+        failed+=test3();
+    }
+    if(failed){
+        failcode|=(1<<2);
+    }
 #endif
 #ifndef T4
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test4(); if(failed) failcode|=(1<<3);
+    failed=0; 
+    for(int i=0;i<NUM_TEST_CALLS;++i){
+        failed+=test4();
+    }
+    if(failed){
+        failcode|=(1<<3);
+    }
 #endif
 #ifndef T5
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test5(); if(failed) failcode|=(1<<4);
+    failed=0;
+    for(int i=0;i<NUM_TEST_CALLS;++i){
+        failed+=test5(); 
+    }
+    if(failed){
+        failcode|=(1<<4);
+    }
 #endif
 #ifndef T6
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test6(); if(failed) failcode|=(1<<5);
+    failed=0;
+    for(int i=0;i<NUM_TEST_CALLS;++i){
+        failed+=test6();
+    }
+    if(failed){
+        failcode|=(1<<5);
+    }
 #endif
 #ifndef T7
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test7(); if(failed) failcode|=(1<<6);
+    failed=0; 
+    for(int i=0;i<NUM_TEST_CALLS;++i){
+        failed+=test7();
+    }
+    if(failed){
+        failcode|=(1<<6);
+    }
 #endif
 
     return failcode;

--- a/Tests/acc_if_condition.c
+++ b/Tests/acc_if_condition.c
@@ -22,12 +22,20 @@
 int test1(void){
     int err = 0;
     real_t *a = (real_t*)malloc(n * sizeof(real_t));
-    if (!a) return 1;
-    for (int i = 0; i < n; ++i) a[i] = (real_t)i;
+    
+    if (!a){
+        return 1;
+    }
+    
+    for (int i = 0; i < n; ++i){
+        a[i] = (real_t)i;
+    }
 
     #pragma acc enter data copyin(a[0:n]) if(0)
 
-    if (acc_is_present(a, (size_t)n * sizeof(real_t))) err++;
+    if (acc_is_present(a, (size_t)n * sizeof(real_t))){
+        err++;
+    }
 
     #pragma acc exit data delete(a[0:n]) if(1)
     free(a);
@@ -41,12 +49,20 @@ int test1(void){
 int test2(void){
     int err = 0;
     real_t *a = (real_t*)malloc(n * sizeof(real_t));
-    if (!a) return 1;
-    for (int i = 0; i < n; ++i) a[i] = (real_t)i;
+    
+    if (!a){
+        return 1;
+    }
+    
+    for (int i = 0; i < n; ++i){
+        a[i] = (real_t)i;
+    }
 
     #pragma acc enter data copyin(a[0:n]) if(1)
 
-    if (!acc_is_present(a, (size_t)n * sizeof(real_t))) err++;
+    if (!acc_is_present(a, (size_t)n * sizeof(real_t))){
+        err++;
+    }
 
     #pragma acc exit data delete(a[0:n]) if(1)
     free(a);
@@ -60,14 +76,24 @@ int test2(void){
 int test3(void){
     int err = 0;
     real_t *a = (real_t*)malloc(n * sizeof(real_t));
-    if (!a) return 1;
-    for (int i = 0; i < n; ++i) a[i] = (real_t)i;
+    
+    if (!a){
+        return 1;
+    }
+    
+    for (int i = 0; i < n; ++i){
+        a[i] = (real_t)i;
+    }
 
     #pragma acc enter data copyin(a[0:n]) if(1)
-    if (!acc_is_present(a, (size_t)n * sizeof(real_t))) err++;
+    if (!acc_is_present(a, (size_t)n * sizeof(real_t))){
+        err++;
+    }
 
     #pragma acc exit data delete(a[0:n]) if(0)
-    if (!acc_is_present(a, (size_t)n * sizeof(real_t))) err++;
+    if (!acc_is_present(a, (size_t)n * sizeof(real_t))){
+        err++;
+    }
 
     #pragma acc exit data delete(a[0:n]) if(1)
     free(a);
@@ -81,14 +107,24 @@ int test3(void){
 int test4(void){
     int err = 0;
     real_t *a = (real_t*)malloc(n * sizeof(real_t));
-    if (!a) return 1;
-    for (int i = 0; i < n; ++i) a[i] = (real_t)i;
+    
+    if (!a){
+        return 1;
+    }
+    
+    for (int i = 0; i < n; ++i){
+        a[i] = (real_t)i;
+    }
 
     #pragma acc enter data copyin(a[0:n]) if(1)
-    if (!acc_is_present(a, (size_t)n * sizeof(real_t))) err++;
+    if (!acc_is_present(a, (size_t)n * sizeof(real_t))){
+        err++;
+    }
 
     #pragma acc exit data delete(a[0:n]) if(1)
-    if (acc_is_present(a, (size_t)n * sizeof(real_t))) err++;
+    if (acc_is_present(a, (size_t)n * sizeof(real_t))){
+        err++;
+    }
 
     free(a);
     return err;
@@ -106,20 +142,38 @@ int test5(void){
     real_t *a = (real_t*)malloc(n*sizeof(real_t));
     real_t *b = (real_t*)malloc(n*sizeof(real_t));
     real_t *c = (real_t*)malloc(n*sizeof(real_t));
-    if (!a || !b || !c){ free(a); free(b); free(c); return 1; }
+    
+    if (!a || !b || !c){
+        free(a); 
+        free(b); 
+        free(c);
+        return 1; 
+    }
 
-    for (int i=0;i<n;++i){ a[i]=rand()/(real_t)(RAND_MAX/10); b[i]=rand()/(real_t)(RAND_MAX/10); c[i]=0; }
+    for (int i=0;i<n;++i){
+        a[i]=rand()/(real_t)(RAND_MAX/10); 
+        b[i]=rand()/(real_t)(RAND_MAX/10); 
+        c[i]=0; 
+    }
 
     int cond_int = (n > 0); // runtime scalar int condition
 
     #pragma acc data copyin(a[0:n],b[0:n]) copyout(c[0:n])
     {
         #pragma acc parallel loop present(a[0:n],b[0:n],c[0:n]) if(cond_int)
-        for (int i=0;i<n;++i) c[i]=a[i]+b[i];
+        for (int i=0;i<n;++i){
+            c[i]=a[i]+b[i];
+        }
     }
 
-    for (int i=0;i<n;++i) if (fabs(c[i]-(a[i]+b[i]))>PRECISION) err++;
-    free(a); free(b); free(c);
+    for (int i=0;i<n;++i){
+        if (fabs(c[i]-(a[i]+b[i]))>PRECISION){
+            err++;
+        }
+    }
+    free(a); 
+    free(b); 
+    free(c);
     return err;
 }
 #endif
@@ -132,20 +186,34 @@ int test6(void){
     srand(SEED);
     real_t *a = (real_t*)malloc(n*sizeof(real_t));
     real_t *c = (real_t*)malloc(n*sizeof(real_t));
-    if (!a || !c){ free(a); free(c); return 1; }
+    if (!a || !c){ 
+        free(a); 
+        free(c); 
+        return 1; 
+    }
 
-    for (int i=0;i<n;++i){ a[i]=rand()/(real_t)(RAND_MAX/10); c[i]=0; }
+    for (int i=0;i<n;++i){ 
+        a[i]=rand()/(real_t)(RAND_MAX/10); 
+        c[i]=0; 
+    }
 
     real_t cond_real = (real_t)1.0; // nonzero scalar => true in C
 
     #pragma acc data copyin(a[0:n]) copyout(c[0:n])
     {
         #pragma acc parallel loop present(a[0:n],c[0:n]) if(cond_real)
-        for (int i=0;i<n;++i) c[i]=a[i]*(real_t)2.0;
+        for (int i=0;i<n;++i){
+            c[i]=a[i]*(real_t)2.0;
+        }
     }
 
-    for (int i=0;i<n;++i) if (fabs(c[i]-(a[i]*(real_t)2.0))>PRECISION) err++;
-    free(a); free(c);
+    for (int i=0;i<n;++i){
+        if (fabs(c[i]-(a[i]*(real_t)2.0))>PRECISION){
+            err++;
+        }
+    }
+    free(a); 
+    free(c);
     return err;
 }
 #endif
@@ -158,20 +226,34 @@ int test7(void){
     srand(SEED);
     real_t *a = (real_t*)malloc(n*sizeof(real_t));
     real_t *c = (real_t*)malloc(n*sizeof(real_t));
-    if (!a || !c){ free(a); free(c); return 1; }
+    if (!a || !c){ 
+        free(a); 
+        free(c); 
+        return 1; 
+    }
 
-    for (int i=0;i<n;++i){ a[i]=rand()/(real_t)(RAND_MAX/10); c[i]=0; }
+    for (int i=0;i<n;++i){ 
+        a[i]=rand()/(real_t)(RAND_MAX/10); 
+        c[i]=0; 
+    }
 
     void* cond_ptr = (void*)a; // non-NULL pointer => true in C
 
     #pragma acc data copyin(a[0:n]) copyout(c[0:n])
     {
         #pragma acc parallel loop present(a[0:n],c[0:n]) if(cond_ptr)
-        for (int i=0;i<n;++i) c[i]=a[i]+(real_t)1.0;
+        for (int i=0;i<n;++i){
+            c[i]=a[i]+(real_t)1.0;
+        }
     }
 
-    for (int i=0;i<n;++i) if (fabs(c[i]-(a[i]+(real_t)1.0))>PRECISION) err++;
-    free(a); free(c);
+    for (int i=0;i<n;++i){
+        if (fabs(c[i]-(a[i]+(real_t)1.0))>PRECISION){
+            err++;
+        }
+    }
+    free(a); 
+    free(c);
     return err;
 }
 #endif

--- a/Tests/acc_if_condition.c
+++ b/Tests/acc_if_condition.c
@@ -1,4 +1,20 @@
 // acc_if_condition.c
+// Validates OpenACC 3.4’s clarified definition of “condition” when used as an argument to the if clause,
+// and verifies that if(condition) correctly gates directive execution (OpenACC 3.4, Section 1.6).
+//
+// Test strategy:
+// 1) Behavior-verifiable data-directive gating (T1–T4):
+//    Uses enter data / exit data with if(true/false) and checks device presence via acc_is_present.
+//    This directly proves that the runtime treats if(false) as a no-op and if(true) as executing the directive.
+//
+// 2) Condition-form coverage for compute constructs (T5–T7):
+//    Confirms the compiler accepts the full set of C-valid “condition” forms in if(...):
+//      - integer scalar expression (T5)
+//      - floating-point scalar condition (T6)  (nonzero => true in C)
+//      - pointer scalar condition (T7)         (non-NULL => true in C)
+//    Each compute test performs a simple device computation and verifies results on the host.
+//
+
 #include "acc_testsuite.h"
 #include <openacc.h>
 #include <stdlib.h>

--- a/Tests/acc_if_condition.c
+++ b/Tests/acc_if_condition.c
@@ -17,8 +17,6 @@
 #include <stddef.h>
 
 #ifndef T1
-//T1:syntax,if-clause,runtime,enter-data,V:3.4-
-// enter data if(0) => must be NO-OP (not present)
 int test1(void){
     int err = 0;
     real_t *a = (real_t*)malloc(n * sizeof(real_t));
@@ -44,8 +42,6 @@ int test1(void){
 #endif
 
 #ifndef T2
-//T2:syntax,if-clause,runtime,enter-data,V:3.4-
-// enter data if(1) => must happen (present)
 int test2(void){
     int err = 0;
     real_t *a = (real_t*)malloc(n * sizeof(real_t));
@@ -71,8 +67,6 @@ int test2(void){
 #endif
 
 #ifndef T3
-//T3:syntax,if-clause,runtime,exit-data,V:3.4-
-// exit data delete if(0) => must be NO-OP (still present)
 int test3(void){
     int err = 0;
     real_t *a = (real_t*)malloc(n * sizeof(real_t));
@@ -102,8 +96,6 @@ int test3(void){
 #endif
 
 #ifndef T4
-//T4:syntax,if-clause,runtime,exit-data,V:3.4-
-// exit data delete if(1) => must delete (not present)
 int test4(void){
     int err = 0;
     real_t *a = (real_t*)malloc(n * sizeof(real_t));
@@ -131,11 +123,8 @@ int test4(void){
 }
 #endif
 
-// ---------- compute-side condition FORM coverage (C rules: any scalar) ----------
 
 #ifndef T5
-//T5:syntax,if-clause,runtime,compute,V:3.4-
-// int scalar expression as condition
 int test5(void){
     int err = 0;
     srand(SEED);
@@ -156,7 +145,7 @@ int test5(void){
         c[i]=0; 
     }
 
-    int cond_int = (n > 0); // runtime scalar int condition
+    int cond_int = (n > 0); 
 
     #pragma acc data copyin(a[0:n],b[0:n]) copyout(c[0:n])
     {
@@ -179,8 +168,6 @@ int test5(void){
 #endif
 
 #ifndef T6
-//T6:syntax,if-clause,runtime,compute,V:3.4-
-// floating-point scalar as condition (C: nonzero => true)
 int test6(void){
     int err = 0;
     srand(SEED);
@@ -197,7 +184,7 @@ int test6(void){
         c[i]=0; 
     }
 
-    real_t cond_real = (real_t)1.0; // nonzero scalar => true in C
+    real_t cond_real = (real_t)1.0; 
 
     #pragma acc data copyin(a[0:n]) copyout(c[0:n])
     {
@@ -219,8 +206,6 @@ int test6(void){
 #endif
 
 #ifndef T7
-//T7:syntax,if-clause,runtime,compute,V:3.4-
-// pointer scalar as condition (C: non-NULL => true)
 int test7(void){
     int err = 0;
     srand(SEED);
@@ -237,7 +222,7 @@ int test7(void){
         c[i]=0; 
     }
 
-    void* cond_ptr = (void*)a; // non-NULL pointer => true in C
+    void* cond_ptr = (void*)a;
 
     #pragma acc data copyin(a[0:n]) copyout(c[0:n])
     {

--- a/Tests/acc_if_condition.cpp
+++ b/Tests/acc_if_condition.cpp
@@ -22,7 +22,6 @@ struct BoolLike {
 };
 
 #ifndef T1
-//T1:syntax,if-clause,runtime,enter-data,V:3.4-
 int test1(){
     int err=0;
     real_t* a=(real_t*)std::malloc(n*sizeof(real_t));
@@ -47,7 +46,6 @@ int test1(){
 #endif
 
 #ifndef T2
-//T2:syntax,if-clause,runtime,enter-data,V:3.4-
 int test2(){
     int err=0;
     real_t* a=(real_t*)std::malloc(n*sizeof(real_t));
@@ -72,7 +70,6 @@ int test2(){
 #endif
 
 #ifndef T3
-//T3:syntax,if-clause,runtime,exit-data,V:3.4-
 int test3(){
     int err=0;
     real_t* a=(real_t*)std::malloc(n*sizeof(real_t));
@@ -102,7 +99,6 @@ int test3(){
 #endif
 
 #ifndef T4
-//T4:syntax,if-clause,runtime,exit-data,V:3.4-
 int test4(){
     int err=0;
     real_t* a=(real_t*)std::malloc(n*sizeof(real_t));
@@ -131,8 +127,6 @@ int test4(){
 #endif
 
 #ifndef T5
-//T5:syntax,if-clause,runtime,compute,V:3.4-
-// int expression condition (valid C++)
 int test5(){
     int err=0;
     std::srand(SEED);
@@ -176,8 +170,6 @@ int test5(){
 #endif
 
 #ifndef T6
-//T6:syntax,if-clause,runtime,compute,V:3.4-
-// C++ condition forms: pointer + user-defined bool-convertible type + fp comparison->bool
 int test6(){
     int err=0;
     std::srand(SEED);
@@ -194,10 +186,10 @@ int test6(){
         c[i]=0; 
     }
 
-    void*   cond_ptr = (void*)a;       // non-null pointer => true
-    BoolLike cond_obj{1};              // operator bool() => true
+    void*   cond_ptr = (void*)a;     
+    BoolLike cond_obj{1};            
     double  x = 1.0;
-    bool    cond_fp = (x != 0.0);      // C++-correct “float-based” condition
+    bool    cond_fp = (x != 0.0);   
 
     #pragma acc data copyin(a[0:n]) copyout(c[0:n])
     {

--- a/Tests/acc_if_condition.cpp
+++ b/Tests/acc_if_condition.cpp
@@ -1,4 +1,21 @@
 // acc_if_condition.cpp
+// Validates OpenACC 3.4’s clarified definition of “condition” when used as an argument to the if clause,
+// and verifies that if(condition) correctly gates directive execution (OpenACC 3.4, Section 1.6).
+//
+// Test strategy:
+// 1) Behavior-verifiable data-directive gating (T1–T4):
+//    Uses enter data / exit data with if(true/false) and checks device presence via acc_is_present.
+//    This directly proves correct gating behavior: if(false) => no-op, if(true) => directive executes.
+//
+// 2) Condition-form coverage for compute constructs under C++ rules (T5–T6):
+//    In C++, a “condition” must be contextually convertible to bool. These tests confirm that OpenACC
+//    accepts C++-legal condition forms in if(...), including:
+//      - integer scalar expression (T5)
+//      - pointer condition, user-defined bool-convertible type (operator bool), and a floating-point
+//        comparison yielding bool (T6)
+//    Each compute region performs simple arithmetic and verifies results on the host.
+//
+
 #include "acc_testsuite.h"
 #include <openacc.h>
 #include <cstdlib>

--- a/Tests/acc_if_condition.cpp
+++ b/Tests/acc_if_condition.cpp
@@ -1,0 +1,173 @@
+// acc_if_condition.cpp
+#include "acc_testsuite.h"
+#include <openacc.h>
+#include <cstdlib>
+#include <cmath>
+#include <cstddef>
+
+struct BoolLike {
+    int v;
+    explicit operator bool() const { return v != 0; }
+};
+
+#ifndef T1
+//T1:syntax,if-clause,runtime,enter-data,V:3.4-
+int test1(){
+    int err=0;
+    real_t* a=(real_t*)std::malloc(n*sizeof(real_t));
+    if(!a) return 1;
+    for(int i=0;i<n;++i) a[i]=(real_t)i;
+
+    #pragma acc enter data copyin(a[0:n]) if(false)
+    if(acc_is_present(a, (size_t)n*sizeof(real_t))) err++;
+
+    #pragma acc exit data delete(a[0:n]) if(true)
+    std::free(a);
+    return err;
+}
+#endif
+
+#ifndef T2
+//T2:syntax,if-clause,runtime,enter-data,V:3.4-
+int test2(){
+    int err=0;
+    real_t* a=(real_t*)std::malloc(n*sizeof(real_t));
+    if(!a) return 1;
+    for(int i=0;i<n;++i) a[i]=(real_t)i;
+
+    #pragma acc enter data copyin(a[0:n]) if(true)
+    if(!acc_is_present(a, (size_t)n*sizeof(real_t))) err++;
+
+    #pragma acc exit data delete(a[0:n]) if(true)
+    std::free(a);
+    return err;
+}
+#endif
+
+#ifndef T3
+//T3:syntax,if-clause,runtime,exit-data,V:3.4-
+int test3(){
+    int err=0;
+    real_t* a=(real_t*)std::malloc(n*sizeof(real_t));
+    if(!a) return 1;
+    for(int i=0;i<n;++i) a[i]=(real_t)i;
+
+    #pragma acc enter data copyin(a[0:n]) if(true)
+    if(!acc_is_present(a, (size_t)n*sizeof(real_t))) err++;
+
+    #pragma acc exit data delete(a[0:n]) if(false)
+    if(!acc_is_present(a, (size_t)n*sizeof(real_t))) err++;
+
+    #pragma acc exit data delete(a[0:n]) if(true)
+    std::free(a);
+    return err;
+}
+#endif
+
+#ifndef T4
+//T4:syntax,if-clause,runtime,exit-data,V:3.4-
+int test4(){
+    int err=0;
+    real_t* a=(real_t*)std::malloc(n*sizeof(real_t));
+    if(!a) return 1;
+    for(int i=0;i<n;++i) a[i]=(real_t)i;
+
+    #pragma acc enter data copyin(a[0:n]) if(true)
+    if(!acc_is_present(a, (size_t)n*sizeof(real_t))) err++;
+
+    #pragma acc exit data delete(a[0:n]) if(true)
+    if(acc_is_present(a, (size_t)n*sizeof(real_t))) err++;
+
+    std::free(a);
+    return err;
+}
+#endif
+
+#ifndef T5
+//T5:syntax,if-clause,runtime,compute,V:3.4-
+// int expression condition (valid C++)
+int test5(){
+    int err=0;
+    std::srand(SEED);
+    real_t* a=(real_t*)std::malloc(n*sizeof(real_t));
+    real_t* b=(real_t*)std::malloc(n*sizeof(real_t));
+    real_t* c=(real_t*)std::malloc(n*sizeof(real_t));
+    if(!a||!b||!c){ std::free(a); std::free(b); std::free(c); return 1; }
+
+    for(int i=0;i<n;++i){ a[i]=std::rand()/(real_t)(RAND_MAX/10); b[i]=std::rand()/(real_t)(RAND_MAX/10); c[i]=0; }
+
+    int cond_int = (n > 0);
+
+    #pragma acc data copyin(a[0:n],b[0:n]) copyout(c[0:n])
+    {
+        #pragma acc parallel loop present(a[0:n],b[0:n],c[0:n]) if(cond_int)
+        for(int i=0;i<n;++i) c[i]=a[i]+b[i];
+    }
+
+    for(int i=0;i<n;++i) if(std::fabs(c[i]-(a[i]+b[i]))>PRECISION) err++;
+    std::free(a); std::free(b); std::free(c);
+    return err;
+}
+#endif
+
+#ifndef T6
+//T6:syntax,if-clause,runtime,compute,V:3.4-
+// C++ condition forms: pointer + user-defined bool-convertible type + fp comparison->bool
+int test6(){
+    int err=0;
+    std::srand(SEED);
+    real_t* a=(real_t*)std::malloc(n*sizeof(real_t));
+    real_t* c=(real_t*)std::malloc(n*sizeof(real_t));
+    if(!a||!c){ std::free(a); std::free(c); return 1; }
+
+    for(int i=0;i<n;++i){ a[i]=std::rand()/(real_t)(RAND_MAX/10); c[i]=0; }
+
+    void*   cond_ptr = (void*)a;       // non-null pointer => true
+    BoolLike cond_obj{1};              // operator bool() => true
+    double  x = 1.0;
+    bool    cond_fp = (x != 0.0);      // C++-correct “float-based” condition
+
+    #pragma acc data copyin(a[0:n]) copyout(c[0:n])
+    {
+        #pragma acc parallel loop present(a[0:n],c[0:n]) if(cond_obj)
+        for(int i=0;i<n;++i) c[i]=a[i]*(real_t)2.0;
+
+        #pragma acc parallel loop present(a[0:n],c[0:n]) if(cond_ptr)
+        for(int i=0;i<n;++i) c[i]=c[i]+(real_t)1.0;
+
+        #pragma acc parallel loop present(a[0:n],c[0:n]) if(cond_fp)
+        for(int i=0;i<n;++i) c[i]=c[i]+(real_t)1.0;
+    }
+
+    for(int i=0;i<n;++i){
+        real_t expect = (a[i]*(real_t)2.0) + (real_t)2.0;
+        if(std::fabs(c[i]-expect)>PRECISION) err++;
+    }
+
+    std::free(a); std::free(c);
+    return err;
+}
+#endif
+
+int main(){
+    int failcode=0, failed;
+#ifndef T1
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test1(); if(failed) failcode|=(1<<0);
+#endif
+#ifndef T2
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test2(); if(failed) failcode|=(1<<1);
+#endif
+#ifndef T3
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test3(); if(failed) failcode|=(1<<2);
+#endif
+#ifndef T4
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test4(); if(failed) failcode|=(1<<3);
+#endif
+#ifndef T5
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test5(); if(failed) failcode|=(1<<4);
+#endif
+#ifndef T6
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test6(); if(failed) failcode|=(1<<5);
+#endif
+    return failcode;
+}

--- a/Tests/acc_if_condition.cpp
+++ b/Tests/acc_if_condition.cpp
@@ -1,19 +1,13 @@
 // acc_if_condition.cpp
-// Validates OpenACC 3.4’s clarified definition of “condition” when used as an argument to the if clause,
-// and verifies that if(condition) correctly gates directive execution (OpenACC 3.4, Section 1.6).
 //
-// Test strategy:
-// 1) Behavior-verifiable data-directive gating (T1–T4):
-//    Uses enter data / exit data with if(true/false) and checks device presence via acc_is_present.
-//    This directly proves correct gating behavior: if(false) => no-op, if(true) => directive executes.
+// Feature under test (OpenACC 3.4, Section 1.6, Feb 2026):
+// - Clarified definition of "condition" when used as an argument to the if clause.
+// - The if(condition) clause must accept any expression that is contextually convertible to bool in C++.
+// - The if clause must correctly gate execution of data and compute directives.
 //
-// 2) Condition-form coverage for compute constructs under C++ rules (T5–T6):
-//    In C++, a “condition” must be contextually convertible to bool. These tests confirm that OpenACC
-//    accepts C++-legal condition forms in if(...), including:
-//      - integer scalar expression (T5)
-//      - pointer condition, user-defined bool-convertible type (operator bool), and a floating-point
-//        comparison yielding bool (T6)
-//    Each compute region performs simple arithmetic and verifies results on the host.
+// Notes:
+// - T1–T4 verify runtime gating behavior for enter data / exit data.
+// - T5–T6 verify valid C++ condition forms (integer, pointer, bool-convertible expressions).
 //
 
 #include "acc_testsuite.h"

--- a/Tests/acc_if_condition.cpp
+++ b/Tests/acc_if_condition.cpp
@@ -233,22 +233,58 @@ int test6(){
 int main(){
     int failcode=0, failed;
 #ifndef T1
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test1(); if(failed) failcode|=(1<<0);
+    failed=0;
+    for(int i=0;i<NUM_TEST_CALLS;++i){
+        failed+=test1();
+    }
+    if(failed){
+        failcode|=(1<<0);
+    }
 #endif
 #ifndef T2
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test2(); if(failed) failcode|=(1<<1);
+    failed=0; 
+    for(int i=0;i<NUM_TEST_CALLS;++i){
+        failed+=test2();
+    }
+    if(failed){
+        failcode|=(1<<1);
+    }
 #endif
 #ifndef T3
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test3(); if(failed) failcode|=(1<<2);
+    failed=0;
+    for(int i=0;i<NUM_TEST_CALLS;++i){
+        failed+=test3();
+    }
+    if(failed){
+        failcode|=(1<<2);
+    }
 #endif
 #ifndef T4
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test4(); if(failed) failcode|=(1<<3);
+    failed=0;
+    for(int i=0;i<NUM_TEST_CALLS;++i){
+        failed+=test4();
+    }
+    if(failed){
+        failcode|=(1<<3);
+    }
 #endif
 #ifndef T5
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test5(); if(failed) failcode|=(1<<4);
+    failed=0;
+    for(int i=0;i<NUM_TEST_CALLS;++i){
+        failed+=test5();
+    }
+    if(failed){
+        failcode|=(1<<4);
+    }
 #endif
 #ifndef T6
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;++i) failed+=test6(); if(failed) failcode|=(1<<5);
+    failed=0;
+    for(int i=0;i<NUM_TEST_CALLS;++i){
+        failed+=test6();
+    }
+    if(failed){
+        failcode|=(1<<5);
+    }
 #endif
     return failcode;
 }

--- a/Tests/acc_if_condition.cpp
+++ b/Tests/acc_if_condition.cpp
@@ -26,11 +26,19 @@ struct BoolLike {
 int test1(){
     int err=0;
     real_t* a=(real_t*)std::malloc(n*sizeof(real_t));
-    if(!a) return 1;
-    for(int i=0;i<n;++i) a[i]=(real_t)i;
+    
+    if(!a){
+        return 1;
+    }
+    
+    for(int i=0;i<n;++i){
+        a[i]=(real_t)i;
+    }
 
     #pragma acc enter data copyin(a[0:n]) if(false)
-    if(acc_is_present(a, (size_t)n*sizeof(real_t))) err++;
+    if(acc_is_present(a, (size_t)n*sizeof(real_t))){
+        err++;
+    }
 
     #pragma acc exit data delete(a[0:n]) if(true)
     std::free(a);
@@ -43,11 +51,19 @@ int test1(){
 int test2(){
     int err=0;
     real_t* a=(real_t*)std::malloc(n*sizeof(real_t));
-    if(!a) return 1;
-    for(int i=0;i<n;++i) a[i]=(real_t)i;
+    
+    if(!a){
+        return 1;
+    }
+    
+    for(int i=0;i<n;++i){
+        a[i]=(real_t)i;
+    }
 
     #pragma acc enter data copyin(a[0:n]) if(true)
-    if(!acc_is_present(a, (size_t)n*sizeof(real_t))) err++;
+    if(!acc_is_present(a, (size_t)n*sizeof(real_t))){
+        err++;
+    }
 
     #pragma acc exit data delete(a[0:n]) if(true)
     std::free(a);
@@ -60,14 +76,24 @@ int test2(){
 int test3(){
     int err=0;
     real_t* a=(real_t*)std::malloc(n*sizeof(real_t));
-    if(!a) return 1;
-    for(int i=0;i<n;++i) a[i]=(real_t)i;
+    
+    if(!a){
+        return 1;
+    }
+    
+    for(int i=0;i<n;++i){
+        a[i]=(real_t)i;
+    }
 
     #pragma acc enter data copyin(a[0:n]) if(true)
-    if(!acc_is_present(a, (size_t)n*sizeof(real_t))) err++;
+    if(!acc_is_present(a, (size_t)n*sizeof(real_t))){
+        err++;
+    }
 
     #pragma acc exit data delete(a[0:n]) if(false)
-    if(!acc_is_present(a, (size_t)n*sizeof(real_t))) err++;
+    if(!acc_is_present(a, (size_t)n*sizeof(real_t))){
+        err++;
+    }
 
     #pragma acc exit data delete(a[0:n]) if(true)
     std::free(a);
@@ -80,14 +106,24 @@ int test3(){
 int test4(){
     int err=0;
     real_t* a=(real_t*)std::malloc(n*sizeof(real_t));
-    if(!a) return 1;
-    for(int i=0;i<n;++i) a[i]=(real_t)i;
+    
+    if(!a){
+        return 1;
+    }
+    
+    for(int i=0;i<n;++i){
+        a[i]=(real_t)i;
+    }
 
     #pragma acc enter data copyin(a[0:n]) if(true)
-    if(!acc_is_present(a, (size_t)n*sizeof(real_t))) err++;
+    if(!acc_is_present(a, (size_t)n*sizeof(real_t))){
+        err++;
+    }
 
     #pragma acc exit data delete(a[0:n]) if(true)
-    if(acc_is_present(a, (size_t)n*sizeof(real_t))) err++;
+    if(acc_is_present(a, (size_t)n*sizeof(real_t))){
+        err++;
+    }
 
     std::free(a);
     return err;
@@ -103,20 +139,38 @@ int test5(){
     real_t* a=(real_t*)std::malloc(n*sizeof(real_t));
     real_t* b=(real_t*)std::malloc(n*sizeof(real_t));
     real_t* c=(real_t*)std::malloc(n*sizeof(real_t));
-    if(!a||!b||!c){ std::free(a); std::free(b); std::free(c); return 1; }
+    if(!a||!b||!c){
+        std::free(a);
+        std::free(b);
+        std::free(c); 
+        return 1; 
+    }
 
-    for(int i=0;i<n;++i){ a[i]=std::rand()/(real_t)(RAND_MAX/10); b[i]=std::rand()/(real_t)(RAND_MAX/10); c[i]=0; }
+    for(int i=0;i<n;++i){
+        a[i]=std::rand()/(real_t)(RAND_MAX/10);
+        b[i]=std::rand()/(real_t)(RAND_MAX/10); 
+        c[i]=0; 
+    }
 
     int cond_int = (n > 0);
 
     #pragma acc data copyin(a[0:n],b[0:n]) copyout(c[0:n])
     {
         #pragma acc parallel loop present(a[0:n],b[0:n],c[0:n]) if(cond_int)
-        for(int i=0;i<n;++i) c[i]=a[i]+b[i];
+        for(int i=0;i<n;++i){
+            c[i]=a[i]+b[i];
+        }
     }
 
-    for(int i=0;i<n;++i) if(std::fabs(c[i]-(a[i]+b[i]))>PRECISION) err++;
-    std::free(a); std::free(b); std::free(c);
+    for(int i=0;i<n;++i){
+        if(std::fabs(c[i]-(a[i]+b[i]))>PRECISION){
+            err++;
+        }
+    }
+    
+    std::free(a);
+    std::free(b); 
+    std::free(c);
     return err;
 }
 #endif
@@ -129,9 +183,16 @@ int test6(){
     std::srand(SEED);
     real_t* a=(real_t*)std::malloc(n*sizeof(real_t));
     real_t* c=(real_t*)std::malloc(n*sizeof(real_t));
-    if(!a||!c){ std::free(a); std::free(c); return 1; }
+    if(!a||!c){
+        std::free(a);
+        std::free(c);
+        return 1; 
+    }
 
-    for(int i=0;i<n;++i){ a[i]=std::rand()/(real_t)(RAND_MAX/10); c[i]=0; }
+    for(int i=0;i<n;++i){
+        a[i]=std::rand()/(real_t)(RAND_MAX/10);
+        c[i]=0; 
+    }
 
     void*   cond_ptr = (void*)a;       // non-null pointer => true
     BoolLike cond_obj{1};              // operator bool() => true
@@ -141,21 +202,30 @@ int test6(){
     #pragma acc data copyin(a[0:n]) copyout(c[0:n])
     {
         #pragma acc parallel loop present(a[0:n],c[0:n]) if(cond_obj)
-        for(int i=0;i<n;++i) c[i]=a[i]*(real_t)2.0;
+        for(int i=0;i<n;++i){
+            c[i]=a[i]*(real_t)2.0;
+        }
 
         #pragma acc parallel loop present(a[0:n],c[0:n]) if(cond_ptr)
-        for(int i=0;i<n;++i) c[i]=c[i]+(real_t)1.0;
+        for(int i=0;i<n;++i){
+            c[i]=c[i]+(real_t)1.0;
+        }
 
         #pragma acc parallel loop present(a[0:n],c[0:n]) if(cond_fp)
-        for(int i=0;i<n;++i) c[i]=c[i]+(real_t)1.0;
+        for(int i=0;i<n;++i){
+            c[i]=c[i]+(real_t)1.0;
+        }
     }
 
     for(int i=0;i<n;++i){
         real_t expect = (a[i]*(real_t)2.0) + (real_t)2.0;
-        if(std::fabs(c[i]-expect)>PRECISION) err++;
+        if(std::fabs(c[i]-expect)>PRECISION){
+            err++;
+        }
     }
 
-    std::free(a); std::free(c);
+    std::free(a); 
+    std::free(c);
     return err;
 }
 #endif


### PR DESCRIPTION
Feature:
–OpenACC 3.4 clarified the definition of a condition when used as the argument to clauses such as if(...), and cleaned up restrictions on the allowed forms of the if clause argument (Specification §1.6).
•The argument to if(...) must be a valid language-defined condition expression.
•The if clause must correctly gate directive behavior at runtime.

What these tests validate:
–Verifies that the OpenACC if clause accepts valid language-defined condition expressions and correctly controls whether directives are executed.
–This PR adds a set of validation and verification tests that exercise both aspects of the clarified feature:

Behavioral semantics of if(condition) (T1–T4)
–These tests use data directives (enter data / exit data) and verify behavior via the OpenACC runtime present table.
•T1: enter data ... if(false)
→ Directive must be a no-op; data must not become present.

•T2: enter data ... if(true)
     → Directive must execute; data must become present.

•T3: exit data delete ... if(false)
     → Delete must be a no-op; data must remain present.

•T4: exit data delete ... if(true)
     → Delete must execute; data must not be present afterward.
–These tests are behavior-verifiable because device presence is directly observed using acc_is_present

Condition-form coverage for compute constructs (T5–T7)
–These tests validate that the if clause accepts all legal condition forms defined by the base language, as clarified in OpenACC 3.4.

•C
–T5: runtime integer scalar condition
–T6: floating-point scalar condition (nonzero ⇒ true)
–T7: pointer scalar condition (non-NULL ⇒ true)

•C++
–T5: integer expression condition
–T6: C++-specific condition forms:
-pointer condition
-user-defined type with operator bool()
-floating-point comparison yielding bool

•Fortran
–T5: LOGICAL variable condition
–T6: LOGICAL expression condition

–These tests ensure that OpenACC correctly defers to the language-specific definition of “condition”, rather than imposing additional restrictions.

--Files:
acc_if_condition.c
acc_if_condition.cpp
acc_if_condition.F90

--Compiler Versions:
NVC: 25.5.0
GCC: 15.2.0
CRAY: 18.0.0
