### PR TITLE
Add integral-constant-expression validation for collapse, tile, cache, and gang clauses.

### DIFF
--- a/Tests/acc_integral_constant_expression.F90
+++ b/Tests/acc_integral_constant_expression.F90
@@ -114,19 +114,15 @@
           cp(i) = 0.0D0
         END DO
         !$acc data copyin(p(1:M_T5)) copy(cp(1:M_T5))
-          ! One-iteration loop: satisfies gfortran "cache must be inside loop"
-          ! and avoids Cray executing cache per-iteration in the real loop.
-          !$acc parallel loop
-          DO i = 1, 1
-            !$acc cache(p(LO_T5:LO_T5+L_T5-1))
-            cp(1) = cp(1)  ! no-op
-          END DO
-          !$acc end parallel loop
+
           !$acc parallel loop
           DO i = 1, M_T5
+            !$acc cache(p(LO_T5:LO_T5+L_T5-1))
             cp(i) = p(i) + 1.0D0
           END DO
           !$acc end parallel loop
+          
+
         !$acc end data
         DO i = 1, M_T5
           IF (ABS(cp(i) - (p(i)+1.0D0)) .GT. PRECISION) errors = errors + 1
@@ -151,17 +147,14 @@
           cq(i) = 0.0D0
         END DO
         !$acc data copyin(q(1:M_T6)) copy(cq(1:M_T6))
-          !$acc parallel loop
-          DO i = 1, 1
-            !$acc cache(q(LO_T6:HI_T6))
-            cq(1) = cq(1)  ! no-op
-          END DO
-          !$acc end parallel loop
+
           !$acc parallel loop
           DO i = 1, M_T6
+            !$acc cache(q(LO_T6:HI_T6))
             cq(i) = q(i) * 2.0D0
           END DO
           !$acc end parallel loop
+
         !$acc end data
         DO i = 1, M_T6
           IF (ABS(cq(i) - 2.0D0*q(i)) .GT. PRECISION) errors = errors + 1

--- a/Tests/acc_integral_constant_expression.F90
+++ b/Tests/acc_integral_constant_expression.F90
@@ -1,6 +1,13 @@
-! Validates that Fortran integer constant expressions declared as PARAMETER are accepted in OpenACC clause arguments that require an integral-constant-expression.
-! Uses PARAMETER constants in collapse, tile, cache bounds/lengths, and gang(dim:) to ensure spec-conformant compile-time constants are handled correctly.
-! Confirms runtime correctness by executing device computations and verifying that results match expected values after returning to the host.
+! acc_integral_constant_expression.F90
+!
+! Feature under test (OpenACC 3.4, Section 1.6, Feb 2026):
+! - Clause arguments that require an integral-constant-expression accept
+!   Fortran integer constant expressions declared with PARAMETER.
+!
+! Notes:
+! - Uses PARAMETER constants in: collapse, tile, cache bounds/lengths,
+!   and gang(dim:) to validate compile-time constant handling.
+
 
 #ifndef T1
 !T1:syntax,collapse-clause,runtime,loop,V:3.4-

--- a/Tests/acc_integral_constant_expression.F90
+++ b/Tests/acc_integral_constant_expression.F90
@@ -4,10 +4,24 @@
 ! - Clause arguments that require an integral-constant-expression accept
 !   Fortran integer constant expressions declared with PARAMETER.
 !
-! Notes:
-! - Uses PARAMETER constants in: collapse, tile, cache bounds/lengths,
-!   and gang(dim:) to validate compile-time constant handling.
-
+!  T1: collapse() accepts an integral-constant-expression (ICE).
+!   This test uses a PARAMETER constant expression in collapse().
+!
+!  T2: tile() accepts an integral-constant-expression (ICE).
+!   This test uses a PARAMETER constant expression in tile().
+!
+!  T3: tile() accepts ICE values.
+!   This test uses PARAMETER ICE values in tile( , ).
+!
+!  T4: cache() slice bounds accept integral-constant-expressions (ICE).
+!   This test uses PARAMETER ICE values in cache(lower:upper).
+!
+!  T5:cache() slice bounds accept integral-constant-expressions (ICE).
+!   This test uses PARAMETER ICE values in cache(lower:upper).
+!
+!  T6: gang(dim:) accepts an integral-constant-expression (ICE) (must be 1..3).
+!   This test uses a PARAMETER ICE value in gang(dim:).
+!
 
 #ifndef T1
 !T1:syntax,collapse-clause,runtime,loop,V:3.4-
@@ -35,7 +49,9 @@
           !$acc end parallel loop
         !$acc end data
         DO idx = 1, M_T2*N_T2
-          IF (ABS(c(idx)-(a(idx)+b(idx))) .GT. PRECISION) errors = errors + 1
+          IF (ABS(c(idx)-(a(idx)+b(idx))) .GT. PRECISION) THEN
+            errors = errors + 1
+          END IF
         END DO
         test1 = (errors .NE. 0)
       END FUNCTION
@@ -62,7 +78,9 @@
           !$acc end parallel loop
         !$acc end data
         DO i = 1, M_T3
-          IF (ABS(c(i) - 2.0D0*a(i)) .GT. PRECISION) errors = errors + 1
+          IF (ABS(c(i) - 2.0D0*a(i)) .GT. PRECISION) THEN
+            errors = errors + 1
+          END IF
         END DO
         test2 = (errors .NE. 0)
       END FUNCTION
@@ -93,7 +111,9 @@
           !$acc end parallel loop
         !$acc end data
         DO idx = 1, M_T4*N_T4
-          IF (ABS(c(idx)-(a(idx)+b(idx))) .GT. PRECISION) errors = errors + 1
+          IF (ABS(c(idx)-(a(idx)+b(idx))) .GT. PRECISION) THEN
+            errors = errors + 1
+          END IF
         END DO
         test3 = (errors .NE. 0)
       END FUNCTION
@@ -125,7 +145,9 @@
 
         !$acc end data
         DO i = 1, M_T5
-          IF (ABS(cp(i) - (p(i)+1.0D0)) .GT. PRECISION) errors = errors + 1
+          IF (ABS(cp(i) - (p(i)+1.0D0)) .GT. PRECISION) THEN
+            errors = errors + 1
+          END IF
         END DO
         test4 = (errors .NE. 0)
       END FUNCTION
@@ -157,7 +179,9 @@
 
         !$acc end data
         DO i = 1, M_T6
-          IF (ABS(cq(i) - 2.0D0*q(i)) .GT. PRECISION) errors = errors + 1
+          IF (ABS(cq(i) - 2.0D0*q(i)) .GT. PRECISION) THEN 
+            errors = errors + 1
+          END IF
         END DO
         test5 = (errors .NE. 0)
       END FUNCTION
@@ -186,7 +210,9 @@
           !$acc end parallel loop
         !$acc end data
         DO i = 1, M_T7
-          IF (ABS(c(i) - 2.0D0*a(i)) .GT. PRECISION) errors = errors + 1
+          IF (ABS(c(i) - 2.0D0*a(i)) .GT. PRECISION) THEN
+            errors = errors + 1
+          END IF
         END DO
         test6 = (errors .NE. 0)
       END FUNCTION
@@ -220,42 +246,54 @@
         DO testrun = 1, NUM_TEST_CALLS
           failed = failed .OR. test1()
         END DO
-        IF (failed) failcode = failcode + 2**0
+        IF (failed) THEN
+            failcode = failcode + 2**0
+        END IF
 #endif
 #ifndef T2
         failed = .FALSE.
         DO testrun = 1, NUM_TEST_CALLS
           failed = failed .OR. test2()
         END DO
-        IF (failed) failcode = failcode + 2**1
+        IF (failed) THEN
+            failcode = failcode + 2**1
+        END IF
 #endif
 #ifndef T3
         failed = .FALSE.
         DO testrun = 1, NUM_TEST_CALLS
           failed = failed .OR. test3()
         END DO
-        IF (failed) failcode = failcode + 2**2
+        IF (failed) THEN
+            failcode = failcode + 2**2
+        END IF
 #endif
 #ifndef T4
         failed = .FALSE.
         DO testrun = 1, NUM_TEST_CALLS
           failed = failed .OR. test4()
         END DO
-        IF (failed) failcode = failcode + 2**3
+        IF (failed) THEN
+            failcode = failcode + 2**3
+        END IF
 #endif
 #ifndef T5
         failed = .FALSE.
         DO testrun = 1, NUM_TEST_CALLS
           failed = failed .OR. test5()
         END DO
-        IF (failed) failcode = failcode + 2**4
+        IF (failed) THEN
+            failcode = failcode + 2**4
+        END IF
 #endif
 #ifndef T6
         failed = .FALSE.
         DO testrun = 1, NUM_TEST_CALLS
           failed = failed .OR. test6()
         END DO
-        IF (failed) failcode = failcode + 2**5
+        IF (failed) THEN
+            failcode = failcode + 2**5
+        END IF
 #endif
         CALL EXIT(failcode)
       END PROGRAM

--- a/Tests/acc_integral_constant_expression.F90
+++ b/Tests/acc_integral_constant_expression.F90
@@ -4,23 +4,14 @@
 ! - Clause arguments that require an integral-constant-expression accept
 !   Fortran integer constant expressions declared with PARAMETER.
 !
-!  T1: collapse() accepts an integral-constant-expression (ICE).
-!   This test uses a PARAMETER constant expression in collapse().
-!
-!  T2: tile() accepts an integral-constant-expression (ICE).
-!   This test uses a PARAMETER constant expression in tile().
-!
-!  T3: tile() accepts ICE values.
-!   This test uses PARAMETER ICE values in tile( , ).
-!
-!  T4: cache() slice bounds accept integral-constant-expressions (ICE).
-!   This test uses PARAMETER ICE values in cache(lower:upper).
-!
-!  T5:cache() slice bounds accept integral-constant-expressions (ICE).
-!   This test uses PARAMETER ICE values in cache(lower:upper).
-!
-!  T6: gang(dim:) accepts an integral-constant-expression (ICE) (must be 1..3).
-!   This test uses a PARAMETER ICE value in gang(dim:).
+! Notes:
+! - T1: collapse() uses a PARAMETER ICE.
+! - T2: tile() uses a PARAMETER ICE.
+! - T3: tile() uses PARAMETER ICE values in tile( , ).
+! - T4: cache() slice bounds use PARAMETER ICE values.
+! - T5: cache() slice bounds use PARAMETER ICE values.
+! - T6: gang(dim:) uses a PARAMETER ICE (must be 1..3).
+!   Some compilers may not support gang(dim:) yet; keep for spec coverage.
 !
 
 #ifndef T1

--- a/Tests/acc_integral_constant_expression.F90
+++ b/Tests/acc_integral_constant_expression.F90
@@ -1,0 +1,337 @@
+#ifndef T1
+!T1:syntax,collapse-clause,runtime,loop,V:3.4-
+      LOGICAL FUNCTION test1()
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER, PARAMETER :: M_T1 = 64, N_T1 = 16
+        INTEGER :: i, j, idx, errors
+        REAL(8), DIMENSION(M_T1*N_T1) :: a, b, c
+
+        errors = 0
+        DO idx = 1, M_T1*N_T1
+          a(idx) = DBLE(idx)
+          b(idx) = DBLE(2*idx)
+          c(idx) = 0.0D0
+        END DO
+
+        !$acc data copyin(a(1:M_T1*N_T1), b(1:M_T1*N_T1)) copy(c(1:M_T1*N_T1))
+          !$acc parallel loop collapse(2)
+          DO i = 1, M_T1
+            DO j = 1, N_T1
+              idx = (i-1)*N_T1 + j
+              c(idx) = a(idx) + b(idx)
+            END DO
+          END DO
+          !$acc end parallel loop
+        !$acc end data
+
+        DO idx = 1, M_T1*N_T1
+          IF (ABS(c(idx)-(a(idx)+b(idx))) .GT. PRECISION) errors = errors + 1
+        END DO
+        test1 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+
+#ifndef T2
+!T2:syntax,collapse-clause,runtime,loop,V:3.4-
+      LOGICAL FUNCTION test2()
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER, PARAMETER :: COLL_T2 = 1 + 1
+        INTEGER, PARAMETER :: M_T2 = 48, N_T2 = 12
+        INTEGER :: i, j, idx, errors
+        REAL(8), DIMENSION(M_T2*N_T2) :: a, b, c
+
+        errors = 0
+        DO idx = 1, M_T2*N_T2
+          a(idx) = DBLE(idx+2)
+          b(idx) = DBLE(idx-1)
+          c(idx) = 0.0D0
+        END DO
+
+        !$acc data copyin(a(1:M_T2*N_T2), b(1:M_T2*N_T2)) copy(c(1:M_T2*N_T2))
+          !$acc parallel loop collapse(COLL_T2)
+          DO i = 1, M_T2
+            DO j = 1, N_T2
+              idx = (i-1)*N_T2 + j
+              c(idx) = a(idx) + b(idx)
+            END DO
+          END DO
+          !$acc end parallel loop
+        !$acc end data
+
+        DO idx = 1, M_T2*N_T2
+          IF (ABS(c(idx)-(a(idx)+b(idx))) .GT. PRECISION) errors = errors + 1
+        END DO
+        test2 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+
+#ifndef T3
+!T3:syntax,tile-clause,runtime,loop,V:3.4-
+      LOGICAL FUNCTION test3()
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER, PARAMETER :: M_T3 = 256
+        INTEGER :: i, errors
+        REAL(8), DIMENSION(M_T3) :: a, c
+
+        errors = 0
+        DO i = 1, M_T3
+          a(i) = DBLE(i)
+          c(i) = 0.0D0
+        END DO
+
+        !$acc data copyin(a(1:M_T3)) copy(c(1:M_T3))
+          !$acc parallel loop tile(2)
+          DO i = 1, M_T3
+            c(i) = 2.0D0 * a(i)
+          END DO
+          !$acc end parallel loop
+        !$acc end data
+
+        DO i = 1, M_T3
+          IF (ABS(c(i) - 2.0D0*a(i)) .GT. PRECISION) errors = errors + 1
+        END DO
+        test3 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+
+#ifndef T4
+!T4:syntax,tile-clause,runtime,loop,V:3.4-
+      LOGICAL FUNCTION test4()
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER, PARAMETER :: TILE2_T4 = 2
+        INTEGER, PARAMETER :: M_T4 = 64, N_T4 = 40
+        INTEGER :: i, j, idx, errors
+        REAL(8), DIMENSION(M_T4*N_T4) :: a, b, c
+
+        errors = 0
+        DO idx = 1, M_T4*N_T4
+          a(idx) = DBLE(idx+1)
+          b(idx) = DBLE(3*idx)
+          c(idx) = 0.0D0
+        END DO
+
+        !$acc data copyin(a(1:M_T4*N_T4), b(1:M_T4*N_T4)) copy(c(1:M_T4*N_T4))
+          !$acc parallel loop tile(TILE2_T4, 2)
+          DO i = 1, M_T4
+            DO j = 1, N_T4
+              idx = (i-1)*N_T4 + j
+              c(idx) = a(idx) + b(idx)
+            END DO
+          END DO
+          !$acc end parallel loop
+        !$acc end data
+
+        DO idx = 1, M_T4*N_T4
+          IF (ABS(c(idx)-(a(idx)+b(idx))) .GT. PRECISION) errors = errors + 1
+        END DO
+        test4 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+#ifndef T5
+!T5:syntax,cache-directive,runtime,compute,V:3.4-
+      LOGICAL FUNCTION test5()
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER, PARAMETER :: M_T5 = 1024
+        INTEGER, PARAMETER :: L_T5 = 16
+        INTEGER, PARAMETER :: LO_T5 = 32
+        INTEGER :: i, errors
+        REAL(8), DIMENSION(M_T5) :: p, cp
+
+        errors = 0
+        DO i = 1, M_T5
+          p(i)  = DBLE(i)
+          cp(i) = 0.0D0
+        END DO
+
+        !$acc data copyin(p(1:M_T5)) copy(cp(1:M_T5))
+
+          ! One-iteration loop: satisfies gfortran "cache must be inside loop"
+          ! and avoids Cray executing cache per-iteration in the real loop.
+          !$acc parallel loop
+          DO i = 1, 1
+            !$acc cache(p(LO_T5:LO_T5+L_T5-1))
+            cp(1) = cp(1)  ! no-op
+          END DO
+          !$acc end parallel loop
+
+          !$acc parallel loop
+          DO i = 1, M_T5
+            cp(i) = p(i) + 1.0D0
+          END DO
+          !$acc end parallel loop
+
+        !$acc end data
+
+        DO i = 1, M_T5
+          IF (ABS(cp(i) - (p(i)+1.0D0)) .GT. PRECISION) errors = errors + 1
+        END DO
+        test5 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+#ifndef T6
+!T6:syntax,cache-directive,runtime,compute,V:3.4-
+      LOGICAL FUNCTION test6()
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER, PARAMETER :: M_T6 = 1024
+        INTEGER, PARAMETER :: LO_T6 = 40
+        INTEGER, PARAMETER :: LEN_T6 = 8
+        INTEGER, PARAMETER :: HI_T6 = LO_T6 + LEN_T6 - 1
+        INTEGER :: i, errors
+        REAL(8), DIMENSION(M_T6) :: q, cq
+
+        errors = 0
+        DO i = 1, M_T6
+          q(i)  = DBLE(i)
+          cq(i) = 0.0D0
+        END DO
+
+        !$acc data copyin(q(1:M_T6)) copy(cq(1:M_T6))
+
+          !$acc parallel loop
+          DO i = 1, 1
+            !$acc cache(q(LO_T6:HI_T6))
+            cq(1) = cq(1)  ! no-op
+          END DO
+          !$acc end parallel loop
+
+          !$acc parallel loop
+          DO i = 1, M_T6
+            cq(i) = q(i) * 2.0D0
+          END DO
+          !$acc end parallel loop
+
+        !$acc end data
+
+        DO i = 1, M_T6
+          IF (ABS(cq(i) - 2.0D0*q(i)) .GT. PRECISION) errors = errors + 1
+        END DO
+        test6 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+#ifndef T7
+!T7:syntax,gang-clause,runtime,loop,V:3.4-
+! gang(dim:DIM_T7) where dim is an integral constant expression (PARAMETER), must evaluate to 1..3
+! NOTE: Some compilers may not support the 'dim:' keyword form yet; keep this as spec conformance coverage.
+      LOGICAL FUNCTION test7()
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER, PARAMETER :: M_T7 = 512
+        INTEGER, PARAMETER :: DIM_T7 = 2
+        INTEGER :: i, errors
+        REAL(8), DIMENSION(M_T7) :: a, c
+
+        errors = 0
+        DO i = 1, M_T7
+          a(i) = DBLE(i)
+          c(i) = 0.0D0
+        END DO
+
+        !$acc data copyin(a(1:M_T7)) copy(c(1:M_T7))
+          !$acc parallel loop gang(dim:DIM_T7)
+          DO i = 1, M_T7
+            c(i) = 2.0D0 * a(i)
+          END DO
+          !$acc end parallel loop
+        !$acc end data
+
+        DO i = 1, M_T7
+          IF (ABS(c(i) - 2.0D0*a(i)) .GT. PRECISION) errors = errors + 1
+        END DO
+
+        test7 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+      PROGRAM main
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: failcode, testrun
+        LOGICAL :: failed
+#ifndef T1
+        LOGICAL :: test1
+#endif
+#ifndef T2
+        LOGICAL :: test2
+#endif
+#ifndef T3
+        LOGICAL :: test3
+#endif
+#ifndef T4
+        LOGICAL :: test4
+#endif
+#ifndef T5
+        LOGICAL :: test5
+#endif
+#ifndef T6
+        LOGICAL :: test6
+#endif
+#ifndef T7
+        LOGICAL :: test7
+#endif
+
+        failcode = 0
+
+#ifndef T1
+        failed = .FALSE.
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .OR. test1()
+        END DO
+        IF (failed) failcode = failcode + 2**0
+#endif
+#ifndef T2
+        failed = .FALSE.
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .OR. test2()
+        END DO
+        IF (failed) failcode = failcode + 2**1
+#endif
+#ifndef T3
+        failed = .FALSE.
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .OR. test3()
+        END DO
+        IF (failed) failcode = failcode + 2**2
+#endif
+#ifndef T4
+        failed = .FALSE.
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .OR. test4()
+        END DO
+        IF (failed) failcode = failcode + 2**3
+#endif
+#ifndef T5
+        failed = .FALSE.
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .OR. test5()
+        END DO
+        IF (failed) failcode = failcode + 2**4
+#endif
+#ifndef T6
+        failed = .FALSE.
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .OR. test6()
+        END DO
+        IF (failed) failcode = failcode + 2**5
+#endif
+#ifndef T7
+        failed = .FALSE.
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .OR. test7()
+        END DO
+        IF (failed) failcode = failcode + 2**6
+#endif
+
+        CALL EXIT(failcode)
+      END PROGRAM

--- a/Tests/acc_integral_constant_expression.c
+++ b/Tests/acc_integral_constant_expression.c
@@ -1,12 +1,29 @@
 // acc_integral_constant_expression.c
+//
 //Feature under test (OpenACC 3.4, Section 1.6, Feb 2026):
 // - Clause arguments that require an integral-constant-expression accept
 //    C integral constant expressions (macros and enum values).
 // 
 //  Notes:
-//  - Uses integral constant expressions in: collapse, tile, cache (index and slice),
-//   and gang(dim:) to validate compile-time constant handling.
-
+//  T1: collapse() accepts an integral-constant-expression (ICE).
+//   This test uses a macro ICE in collapse() and checks runtime correctness.
+//  
+//  T2: tile() accepts an integral-constant-expression (ICE).
+//   This test uses a macro ICE in tile() and checks runtime correctness.
+//
+//  T3: tile() accepts ICE values (enums/macros).
+//   This test mixes enum + macro ICE in tile() and checks correctness.
+//
+//  T4: cache() indexing accepts an integral-constant-expression (ICE).
+//   This test uses an enum ICE as the cache element index.
+//
+//  T5: cache() subarray slices accept ICE values.
+//   This test uses enum/macro ICE for lower:length in cache().
+//
+//  T6: gang(dim:) accepts an integral-constant-expression (ICE) (valid range 1..3).
+//   This test uses an enum ICE in gang(dim:) and checks runtime correctness.
+// – Some compilers may not support the 'dim:' keyword form yet; keep this as spec conformance coverage.
+//
 
 #include "acc_testsuite.h"
 #include <openacc.h>
@@ -21,8 +38,6 @@ enum { ICE_ENUM2 = 2, ICE_ENUM4 = 4, ICE_ENUM_LOWER = 3 };
 #define ICE_LEN4     (4)
 
 #ifndef T1
-//T1:syntax,collapse-clause,runtime,loop,V:3.4-
-// collapse(ICE_MACRO2) macro arithmetic ICE
 int test1(void){
     int err = 0;
     const int M = 48, N = 12;
@@ -36,7 +51,11 @@ int test1(void){
         free(c);
         return 1;
     }
-    for(int i=0;i<MN;i++){ a[i]=(real_t)(i+2); b[i]=(real_t)(i-1); c[i]=0; }
+    for(int i=0;i<MN;i++){ 
+        a[i]=(real_t)(i+2); 
+        b[i]=(real_t)(i-1); 
+        c[i]=0; 
+    }
     #pragma acc data copyin(a[0:MN],b[0:MN]) copyout(c[0:MN])
     {
         #pragma acc parallel loop collapse(ICE_MACRO2)
@@ -48,7 +67,9 @@ int test1(void){
         }
     }
     for (int i = 0; i < MN; ++i) {
-        if (fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+        if (fabs(c[i] - (a[i] + b[i])) > PRECISION){
+            err++;
+        }
     }
 
     free(a);
@@ -58,8 +79,6 @@ int test1(void){
 }
 #endif
 #ifndef T2
-//T2:syntax,tile-clause,runtime,loop,V:3.4-
-// tile(ICE_TILE1) macro ICE
 int test2(void){
     int err = 0;
     const int M = 256;
@@ -70,7 +89,11 @@ int test2(void){
         free(c);
         return 1;
     }
-    for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=0; }
+    for(int i=0;i<M;i++){
+        a[i]=(real_t)i; 
+        c[i]=0; 
+    }
+    
     #pragma acc data copyin(a[0:M]) copyout(c[0:M])
     {
         #pragma acc parallel loop tile(ICE_TILE1)
@@ -79,7 +102,9 @@ int test2(void){
         }
     }
     for(int i=0;i<M;i++){
-        if (fabs(c[i] - a[i]*(real_t)2.0) > PRECISION) err++;
+        if (fabs(c[i] - a[i]*(real_t)2.0) > PRECISION){
+            err++;
+        }
     }
     free(a);
     free(c);
@@ -87,8 +112,6 @@ int test2(void){
 }
 #endif
 #ifndef T3
-//T3:syntax,tile-clause,runtime,loop,V:3.4-
-// tile(ICE_ENUM2, ICE_MACRO2) enum + macro ICE
 int test3(void){
     int err = 0;
     const int M = 64, N = 40;
@@ -102,7 +125,13 @@ int test3(void){
         free(c);
         return 1;
     }
-    for(int i=0;i<MN;i++){ a[i]=(real_t)(i+1); b[i]=(real_t)(3*i); c[i]=0; }
+    
+    for(int i=0;i<MN;i++){
+        a[i]=(real_t)(i+1); 
+        b[i]=(real_t)(3*i); 
+        c[i]=0; 
+    }
+    
     #pragma acc data copyin(a[0:MN],b[0:MN]) copyout(c[0:MN])
     {
         #pragma acc parallel loop tile(ICE_ENUM2, ICE_MACRO2)
@@ -114,7 +143,9 @@ int test3(void){
         }
     }
     for (int i = 0; i < MN; ++i) {
-        if (fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+        if (fabs(c[i] - (a[i] + b[i])) > PRECISION){
+            err++;
+        }
     }
 
     free(a);
@@ -124,8 +155,6 @@ int test3(void){
 }
 #endif
 #ifndef T4
-//T4:syntax,cache-directive,runtime,loop,V:3.4-
-// cache: element index uses ICE (enum)
 int test4(void){
     int err = 0;
     const int M = 512;
@@ -136,7 +165,12 @@ int test4(void){
         free(c);
         return 1;
     }
-    for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=0; }
+    
+    for(int i=0;i<M;i++){
+        a[i]=(real_t)i;
+        c[i]=0; 
+    }
+    
     #pragma acc data copyin(a[0:M]) copyout(c[0:M])
     {
         #pragma acc parallel loop
@@ -145,17 +179,19 @@ int test4(void){
             c[i] = a[i] + (real_t)1.0;
         }
     }
+    
     for(int i=0;i<M;i++){
-        if (fabs(c[i] - (a[i]+(real_t)1.0)) > PRECISION) err++;
+        if (fabs(c[i] - (a[i]+(real_t)1.0)) > PRECISION){
+            err++;
+        }
     }
+    
     free(a);
     free(c);
     return err;
 }
 #endif
 #ifndef T5
-//T5:syntax,cache-directive,runtime,loop,V:3.4-
-// cache: subarray lower:length uses ICE lower + ICE length
 int test5(void){
     int err = 0;
     const int M = 512;
@@ -166,7 +202,10 @@ int test5(void){
         free(c);
         return 1;
     }
-    for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=a[i]; }
+    for(int i=0;i<M;i++){
+        a[i]=(real_t)i; 
+        c[i]=a[i]; 
+    }
     #pragma acc data copyin(a[0:M]) copy(c[0:M])
     {
         #pragma acc parallel loop
@@ -175,18 +214,19 @@ int test5(void){
             c[i] = c[i] + (real_t)2.0;
         }
     }
+    
     for(int i=0;i<M;i++){
-        if (fabs(c[i] - (a[i]+(real_t)2.0)) > PRECISION) err++;
+        if (fabs(c[i] - (a[i]+(real_t)2.0)) > PRECISION){
+            err++;
+        }
     }
+    
     free(a);
     free(c);
     return err;
 }
 #endif
 #ifndef T6
-//T6:syntax,gang-clause,runtime,loop,V:3.4-
-// gang(dim:ICE_ENUM2) where dim is an integral-constant-expression (enum), must evaluate to 1..3
-// NOTE: Some compilers may not support the 'dim:' keyword form yet; keep this as spec conformance coverage.
 int test6(void){
     int err = 0;
     const int M = 512;
@@ -197,7 +237,12 @@ int test6(void){
         free(c);
         return 1;
     }
-    for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=0; }
+    
+    for(int i=0;i<M;i++){
+        a[i]=(real_t)i;
+        c[i]=0; 
+    }
+    
     #pragma acc data copyin(a[0:M]) copyout(c[0:M])
     {
         #pragma acc parallel loop gang(dim:ICE_ENUM2)
@@ -205,9 +250,13 @@ int test6(void){
             c[i] = a[i] * (real_t)2.0;
         }
     }
+    
     for(int i=0;i<M;i++){
-        if (fabs(c[i] - a[i]*(real_t)2.0) > PRECISION) err++;
+        if (fabs(c[i] - a[i]*(real_t)2.0) > PRECISION){
+            err++;
+        }
     }
+    
     free(a);
     free(c);
     return err;
@@ -216,22 +265,58 @@ int test6(void){
 int main(void){
     int failcode=0, failed;
 #ifndef T1
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test1(); if(failed) failcode|=(1<<0);
+    failed=0; 
+    for(int i=0;i<NUM_TEST_CALLS;i++){
+        failed+=test1();
+    }
+    if(failed){
+        failcode|=(1<<0);
+    }
 #endif
 #ifndef T2
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test2(); if(failed) failcode|=(1<<1);
+    failed=0; 
+    for(int i=0;i<NUM_TEST_CALLS;i++){
+        failed+=test2(); 
+    }
+    if(failed){
+        failcode|=(1<<1);
+    }
 #endif
 #ifndef T3
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test3(); if(failed) failcode|=(1<<2);
+    failed=0; 
+    for(int i=0;i<NUM_TEST_CALLS;i++){
+        failed+=test3(); 
+    }
+    if(failed){
+        failcode|=(1<<2);
+    }
 #endif
 #ifndef T4
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test4(); if(failed) failcode|=(1<<3);
+    failed=0; 
+    for(int i=0;i<NUM_TEST_CALLS;i++){
+        failed+=test4(); 
+    }
+    if(failed){
+        failcode|=(1<<3);
+    }
 #endif
 #ifndef T5
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test5(); if(failed) failcode|=(1<<4);
+    failed=0; 
+    for(int i=0;i<NUM_TEST_CALLS;i++){
+        failed+=test5(); 
+    }
+    if(failed){
+        failcode|=(1<<4);
+    }
 #endif
 #ifndef T6
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test6(); if(failed) failcode|=(1<<5);
+    failed=0; 
+    for(int i=0;i<NUM_TEST_CALLS;i++){
+        failed+=test6(); 
+    }
+    if(failed){
+        failcode|=(1<<5);
+    }
 #endif
     return failcode;
 }

--- a/Tests/acc_integral_constant_expression.c
+++ b/Tests/acc_integral_constant_expression.c
@@ -1,10 +1,13 @@
 // acc_integral_constant_expression.c
+// Validates that C integral constant expressions (macros and enums) are accepted in OpenACC clause arguments where the spec requires an integral-constant-expression.
+// Uses constant expressions in clauses such as collapse, tile, cache indexing/slices, and gang(dim:) to ensure the compiler parses and applies them correctly.
+// Each test performs simple array computations on the device and verifies results on the host to confirm correct runtime behavior.
+
 #include "acc_testsuite.h"
 #include <openacc.h>
 #include <stdlib.h>
 #include <math.h>
 #include <stddef.h>
-
 // C integer constant expressions: enums + macros
 enum { ICE_ENUM2 = 2, ICE_ENUM4 = 4, ICE_ENUM_LOWER = 3 };
 #define ICE_MACRO2   (1 + 1)
@@ -12,59 +15,23 @@ enum { ICE_ENUM2 = 2, ICE_ENUM4 = 4, ICE_ENUM_LOWER = 3 };
 #define ICE_TILE2    (ICE_MACRO2)   // still ICE
 #define ICE_LEN4     (4)
 
-static int check_vec_add(const real_t* a, const real_t* b, const real_t* c, int nloc){
-    int err = 0;
-    for(int i=0;i<nloc;i++){
-        if (fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
-    }
-    return err;
-}
-
 #ifndef T1
 //T1:syntax,collapse-clause,runtime,loop,V:3.4-
-// collapse(2) literal ICE (positive, non-zero)
-int test1(void){
-    int err = 0;
-    const int M = 64, N = 16;
-    const int MN = M*N;
-    real_t *a=(real_t*)malloc((size_t)MN*sizeof(real_t));
-    real_t *b=(real_t*)malloc((size_t)MN*sizeof(real_t));
-    real_t *c=(real_t*)malloc((size_t)MN*sizeof(real_t));
-    if(!a||!b||!c){ free(a); free(b); free(c); return 1; }
-
-    for(int i=0;i<MN;i++){ a[i]=(real_t)i; b[i]=(real_t)(2*i); c[i]=0; }
-
-    #pragma acc data copyin(a[0:MN],b[0:MN]) copyout(c[0:MN])
-    {
-        #pragma acc parallel loop collapse(2)
-        for(int i=0;i<M;i++){
-            for(int j=0;j<N;j++){
-                int idx = i*N + j;
-                c[idx] = a[idx] + b[idx];
-            }
-        }
-    }
-
-    err += check_vec_add(a,b,c,MN);
-    free(a); free(b); free(c);
-    return err;
-}
-#endif
-
-#ifndef T2
-//T2:syntax,collapse-clause,runtime,loop,V:3.4-
 // collapse(ICE_MACRO2) macro arithmetic ICE
-int test2(void){
+int test1(void){
     int err = 0;
     const int M = 48, N = 12;
     const int MN = M*N;
     real_t *a=(real_t*)malloc((size_t)MN*sizeof(real_t));
     real_t *b=(real_t*)malloc((size_t)MN*sizeof(real_t));
     real_t *c=(real_t*)malloc((size_t)MN*sizeof(real_t));
-    if(!a||!b||!c){ free(a); free(b); free(c); return 1; }
-
+    if(!a||!b||!c){
+        free(a);
+        free(b);
+        free(c);
+        return 1;
+    }
     for(int i=0;i<MN;i++){ a[i]=(real_t)(i+2); b[i]=(real_t)(i-1); c[i]=0; }
-
     #pragma acc data copyin(a[0:MN],b[0:MN]) copyout(c[0:MN])
     {
         #pragma acc parallel loop collapse(ICE_MACRO2)
@@ -75,25 +42,30 @@ int test2(void){
             }
         }
     }
+    for (int i = 0; i < MN; ++i) {
+        if (fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+    }
 
-    err += check_vec_add(a,b,c,MN);
-    free(a); free(b); free(c);
+    free(a);
+    free(b);
+    free(c);
     return err;
 }
 #endif
-
-#ifndef T3
-//T3:syntax,tile-clause,runtime,loop,V:3.4-
-// tile(2) literal ICE
-int test3(void){
+#ifndef T2
+//T2:syntax,tile-clause,runtime,loop,V:3.4-
+// tile(ICE_TILE1) macro ICE
+int test2(void){
     int err = 0;
     const int M = 256;
     real_t *a=(real_t*)malloc((size_t)M*sizeof(real_t));
     real_t *c=(real_t*)malloc((size_t)M*sizeof(real_t));
-    if(!a||!c){ free(a); free(c); return 1; }
-
+    if(!a||!c){
+        free(a);
+        free(c);
+        return 1;
+    }
     for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=0; }
-
     #pragma acc data copyin(a[0:M]) copyout(c[0:M])
     {
         #pragma acc parallel loop tile(ICE_TILE1)
@@ -101,29 +73,31 @@ int test3(void){
             c[i] = a[i] * (real_t)2.0;
         }
     }
-
     for(int i=0;i<M;i++){
         if (fabs(c[i] - a[i]*(real_t)2.0) > PRECISION) err++;
     }
-    free(a); free(c);
+    free(a);
+    free(c);
     return err;
 }
 #endif
-
-#ifndef T4
-//T4:syntax,tile-clause,runtime,loop,V:3.4-
+#ifndef T3
+//T3:syntax,tile-clause,runtime,loop,V:3.4-
 // tile(ICE_ENUM2, ICE_MACRO2) enum + macro ICE
-int test4(void){
+int test3(void){
     int err = 0;
     const int M = 64, N = 40;
     const int MN = M*N;
     real_t *a=(real_t*)malloc((size_t)MN*sizeof(real_t));
     real_t *b=(real_t*)malloc((size_t)MN*sizeof(real_t));
     real_t *c=(real_t*)malloc((size_t)MN*sizeof(real_t));
-    if(!a||!b||!c){ free(a); free(b); free(c); return 1; }
-
+    if(!a||!b||!c){
+        free(a);
+        free(b);
+        free(c);
+        return 1;
+    }
     for(int i=0;i<MN;i++){ a[i]=(real_t)(i+1); b[i]=(real_t)(3*i); c[i]=0; }
-
     #pragma acc data copyin(a[0:MN],b[0:MN]) copyout(c[0:MN])
     {
         #pragma acc parallel loop tile(ICE_ENUM2, ICE_MACRO2)
@@ -134,25 +108,30 @@ int test4(void){
             }
         }
     }
+    for (int i = 0; i < MN; ++i) {
+        if (fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+    }
 
-    err += check_vec_add(a,b,c,MN);
-    free(a); free(b); free(c);
+    free(a);
+    free(b);
+    free(c);
     return err;
 }
 #endif
-
-#ifndef T5
-//T5:syntax,cache-directive,runtime,loop,V:3.4-
+#ifndef T4
+//T4:syntax,cache-directive,runtime,loop,V:3.4-
 // cache: element index uses ICE (enum)
-int test5(void){
+int test4(void){
     int err = 0;
     const int M = 512;
     real_t *a=(real_t*)malloc((size_t)M*sizeof(real_t));
     real_t *c=(real_t*)malloc((size_t)M*sizeof(real_t));
-    if(!a||!c){ free(a); free(c); return 1; }
-
+    if(!a||!c){
+        free(a);
+        free(c);
+        return 1;
+    }
     for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=0; }
-
     #pragma acc data copyin(a[0:M]) copyout(c[0:M])
     {
         #pragma acc parallel loop
@@ -161,27 +140,28 @@ int test5(void){
             c[i] = a[i] + (real_t)1.0;
         }
     }
-
     for(int i=0;i<M;i++){
         if (fabs(c[i] - (a[i]+(real_t)1.0)) > PRECISION) err++;
     }
-    free(a); free(c);
+    free(a);
+    free(c);
     return err;
 }
 #endif
-
-#ifndef T6
-//T6:syntax,cache-directive,runtime,loop,V:3.4-
+#ifndef T5
+//T5:syntax,cache-directive,runtime,loop,V:3.4-
 // cache: subarray lower:length uses ICE lower + ICE length
-int test6(void){
+int test5(void){
     int err = 0;
     const int M = 512;
     real_t *a=(real_t*)malloc((size_t)M*sizeof(real_t));
     real_t *c=(real_t*)malloc((size_t)M*sizeof(real_t));
-    if(!a||!c){ free(a); free(c); return 1; }
-
+    if(!a||!c){
+        free(a);
+        free(c);
+        return 1;
+    }
     for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=a[i]; }
-
     #pragma acc data copyin(a[0:M]) copy(c[0:M])
     {
         #pragma acc parallel loop
@@ -190,28 +170,29 @@ int test6(void){
             c[i] = c[i] + (real_t)2.0;
         }
     }
-
     for(int i=0;i<M;i++){
         if (fabs(c[i] - (a[i]+(real_t)2.0)) > PRECISION) err++;
     }
-    free(a); free(c);
+    free(a);
+    free(c);
     return err;
 }
 #endif
-
-#ifndef T7
-//T7:syntax,gang-clause,runtime,loop,V:3.4-
+#ifndef T6
+//T6:syntax,gang-clause,runtime,loop,V:3.4-
 // gang(dim:ICE_ENUM2) where dim is an integral-constant-expression (enum), must evaluate to 1..3
 // NOTE: Some compilers may not support the 'dim:' keyword form yet; keep this as spec conformance coverage.
-int test7(void){
+int test6(void){
     int err = 0;
     const int M = 512;
     real_t *a=(real_t*)malloc((size_t)M*sizeof(real_t));
     real_t *c=(real_t*)malloc((size_t)M*sizeof(real_t));
-    if(!a||!c){ free(a); free(c); return 1; }
-
+    if(!a||!c){
+        free(a);
+        free(c);
+        return 1;
+    }
     for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=0; }
-
     #pragma acc data copyin(a[0:M]) copyout(c[0:M])
     {
         #pragma acc parallel loop gang(dim:ICE_ENUM2)
@@ -219,16 +200,14 @@ int test7(void){
             c[i] = a[i] * (real_t)2.0;
         }
     }
-
     for(int i=0;i<M;i++){
         if (fabs(c[i] - a[i]*(real_t)2.0) > PRECISION) err++;
     }
-
-    free(a); free(c);
+    free(a);
+    free(c);
     return err;
 }
 #endif
-
 int main(void){
     int failcode=0, failed;
 #ifndef T1
@@ -248,9 +227,6 @@ int main(void){
 #endif
 #ifndef T6
     failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test6(); if(failed) failcode|=(1<<5);
-#endif
-#ifndef T7
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test7(); if(failed) failcode|=(1<<6);
 #endif
     return failcode;
 }

--- a/Tests/acc_integral_constant_expression.c
+++ b/Tests/acc_integral_constant_expression.c
@@ -1,0 +1,256 @@
+// acc_integral_constant_expression.c
+#include "acc_testsuite.h"
+#include <openacc.h>
+#include <stdlib.h>
+#include <math.h>
+#include <stddef.h>
+
+// C integer constant expressions: enums + macros
+enum { ICE_ENUM2 = 2, ICE_ENUM4 = 4, ICE_ENUM_LOWER = 3 };
+#define ICE_MACRO2   (1 + 1)
+#define ICE_TILE1    (2)
+#define ICE_TILE2    (ICE_MACRO2)   // still ICE
+#define ICE_LEN4     (4)
+
+static int check_vec_add(const real_t* a, const real_t* b, const real_t* c, int nloc){
+    int err = 0;
+    for(int i=0;i<nloc;i++){
+        if (fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+    }
+    return err;
+}
+
+#ifndef T1
+//T1:syntax,collapse-clause,runtime,loop,V:3.4-
+// collapse(2) literal ICE (positive, non-zero)
+int test1(void){
+    int err = 0;
+    const int M = 64, N = 16;
+    const int MN = M*N;
+    real_t *a=(real_t*)malloc((size_t)MN*sizeof(real_t));
+    real_t *b=(real_t*)malloc((size_t)MN*sizeof(real_t));
+    real_t *c=(real_t*)malloc((size_t)MN*sizeof(real_t));
+    if(!a||!b||!c){ free(a); free(b); free(c); return 1; }
+
+    for(int i=0;i<MN;i++){ a[i]=(real_t)i; b[i]=(real_t)(2*i); c[i]=0; }
+
+    #pragma acc data copyin(a[0:MN],b[0:MN]) copyout(c[0:MN])
+    {
+        #pragma acc parallel loop collapse(2)
+        for(int i=0;i<M;i++){
+            for(int j=0;j<N;j++){
+                int idx = i*N + j;
+                c[idx] = a[idx] + b[idx];
+            }
+        }
+    }
+
+    err += check_vec_add(a,b,c,MN);
+    free(a); free(b); free(c);
+    return err;
+}
+#endif
+
+#ifndef T2
+//T2:syntax,collapse-clause,runtime,loop,V:3.4-
+// collapse(ICE_MACRO2) macro arithmetic ICE
+int test2(void){
+    int err = 0;
+    const int M = 48, N = 12;
+    const int MN = M*N;
+    real_t *a=(real_t*)malloc((size_t)MN*sizeof(real_t));
+    real_t *b=(real_t*)malloc((size_t)MN*sizeof(real_t));
+    real_t *c=(real_t*)malloc((size_t)MN*sizeof(real_t));
+    if(!a||!b||!c){ free(a); free(b); free(c); return 1; }
+
+    for(int i=0;i<MN;i++){ a[i]=(real_t)(i+2); b[i]=(real_t)(i-1); c[i]=0; }
+
+    #pragma acc data copyin(a[0:MN],b[0:MN]) copyout(c[0:MN])
+    {
+        #pragma acc parallel loop collapse(ICE_MACRO2)
+        for(int i=0;i<M;i++){
+            for(int j=0;j<N;j++){
+                int idx = i*N + j;
+                c[idx] = a[idx] + b[idx];
+            }
+        }
+    }
+
+    err += check_vec_add(a,b,c,MN);
+    free(a); free(b); free(c);
+    return err;
+}
+#endif
+
+#ifndef T3
+//T3:syntax,tile-clause,runtime,loop,V:3.4-
+// tile(2) literal ICE
+int test3(void){
+    int err = 0;
+    const int M = 256;
+    real_t *a=(real_t*)malloc((size_t)M*sizeof(real_t));
+    real_t *c=(real_t*)malloc((size_t)M*sizeof(real_t));
+    if(!a||!c){ free(a); free(c); return 1; }
+
+    for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=0; }
+
+    #pragma acc data copyin(a[0:M]) copyout(c[0:M])
+    {
+        #pragma acc parallel loop tile(ICE_TILE1)
+        for(int i=0;i<M;i++){
+            c[i] = a[i] * (real_t)2.0;
+        }
+    }
+
+    for(int i=0;i<M;i++){
+        if (fabs(c[i] - a[i]*(real_t)2.0) > PRECISION) err++;
+    }
+    free(a); free(c);
+    return err;
+}
+#endif
+
+#ifndef T4
+//T4:syntax,tile-clause,runtime,loop,V:3.4-
+// tile(ICE_ENUM2, ICE_MACRO2) enum + macro ICE
+int test4(void){
+    int err = 0;
+    const int M = 64, N = 40;
+    const int MN = M*N;
+    real_t *a=(real_t*)malloc((size_t)MN*sizeof(real_t));
+    real_t *b=(real_t*)malloc((size_t)MN*sizeof(real_t));
+    real_t *c=(real_t*)malloc((size_t)MN*sizeof(real_t));
+    if(!a||!b||!c){ free(a); free(b); free(c); return 1; }
+
+    for(int i=0;i<MN;i++){ a[i]=(real_t)(i+1); b[i]=(real_t)(3*i); c[i]=0; }
+
+    #pragma acc data copyin(a[0:MN],b[0:MN]) copyout(c[0:MN])
+    {
+        #pragma acc parallel loop tile(ICE_ENUM2, ICE_MACRO2)
+        for(int i=0;i<M;i++){
+            for(int j=0;j<N;j++){
+                int idx = i*N + j;
+                c[idx] = a[idx] + b[idx];
+            }
+        }
+    }
+
+    err += check_vec_add(a,b,c,MN);
+    free(a); free(b); free(c);
+    return err;
+}
+#endif
+
+#ifndef T5
+//T5:syntax,cache-directive,runtime,loop,V:3.4-
+// cache: element index uses ICE (enum)
+int test5(void){
+    int err = 0;
+    const int M = 512;
+    real_t *a=(real_t*)malloc((size_t)M*sizeof(real_t));
+    real_t *c=(real_t*)malloc((size_t)M*sizeof(real_t));
+    if(!a||!c){ free(a); free(c); return 1; }
+
+    for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=0; }
+
+    #pragma acc data copyin(a[0:M]) copyout(c[0:M])
+    {
+        #pragma acc parallel loop
+        for(int i=0;i<M;i++){
+            #pragma acc cache(a[ICE_ENUM2])
+            c[i] = a[i] + (real_t)1.0;
+        }
+    }
+
+    for(int i=0;i<M;i++){
+        if (fabs(c[i] - (a[i]+(real_t)1.0)) > PRECISION) err++;
+    }
+    free(a); free(c);
+    return err;
+}
+#endif
+
+#ifndef T6
+//T6:syntax,cache-directive,runtime,loop,V:3.4-
+// cache: subarray lower:length uses ICE lower + ICE length
+int test6(void){
+    int err = 0;
+    const int M = 512;
+    real_t *a=(real_t*)malloc((size_t)M*sizeof(real_t));
+    real_t *c=(real_t*)malloc((size_t)M*sizeof(real_t));
+    if(!a||!c){ free(a); free(c); return 1; }
+
+    for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=a[i]; }
+
+    #pragma acc data copyin(a[0:M]) copy(c[0:M])
+    {
+        #pragma acc parallel loop
+        for(int i=0;i<M;i++){
+            #pragma acc cache(a[ICE_ENUM_LOWER:ICE_LEN4])
+            c[i] = c[i] + (real_t)2.0;
+        }
+    }
+
+    for(int i=0;i<M;i++){
+        if (fabs(c[i] - (a[i]+(real_t)2.0)) > PRECISION) err++;
+    }
+    free(a); free(c);
+    return err;
+}
+#endif
+
+#ifndef T7
+//T7:syntax,gang-clause,runtime,loop,V:3.4-
+// gang(dim:ICE_ENUM2) where dim is an integral-constant-expression (enum), must evaluate to 1..3
+// NOTE: Some compilers may not support the 'dim:' keyword form yet; keep this as spec conformance coverage.
+int test7(void){
+    int err = 0;
+    const int M = 512;
+    real_t *a=(real_t*)malloc((size_t)M*sizeof(real_t));
+    real_t *c=(real_t*)malloc((size_t)M*sizeof(real_t));
+    if(!a||!c){ free(a); free(c); return 1; }
+
+    for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=0; }
+
+    #pragma acc data copyin(a[0:M]) copyout(c[0:M])
+    {
+        #pragma acc parallel loop gang(dim:ICE_ENUM2)
+        for(int i=0;i<M;i++){
+            c[i] = a[i] * (real_t)2.0;
+        }
+    }
+
+    for(int i=0;i<M;i++){
+        if (fabs(c[i] - a[i]*(real_t)2.0) > PRECISION) err++;
+    }
+
+    free(a); free(c);
+    return err;
+}
+#endif
+
+int main(void){
+    int failcode=0, failed;
+#ifndef T1
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test1(); if(failed) failcode|=(1<<0);
+#endif
+#ifndef T2
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test2(); if(failed) failcode|=(1<<1);
+#endif
+#ifndef T3
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test3(); if(failed) failcode|=(1<<2);
+#endif
+#ifndef T4
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test4(); if(failed) failcode|=(1<<3);
+#endif
+#ifndef T5
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test5(); if(failed) failcode|=(1<<4);
+#endif
+#ifndef T6
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test6(); if(failed) failcode|=(1<<5);
+#endif
+#ifndef T7
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test7(); if(failed) failcode|=(1<<6);
+#endif
+    return failcode;
+}

--- a/Tests/acc_integral_constant_expression.c
+++ b/Tests/acc_integral_constant_expression.c
@@ -1,7 +1,12 @@
 // acc_integral_constant_expression.c
-// Validates that C integral constant expressions (macros and enums) are accepted in OpenACC clause arguments where the spec requires an integral-constant-expression.
-// Uses constant expressions in clauses such as collapse, tile, cache indexing/slices, and gang(dim:) to ensure the compiler parses and applies them correctly.
-// Each test performs simple array computations on the device and verifies results on the host to confirm correct runtime behavior.
+//Feature under test (OpenACC 3.4, Section 1.6, Feb 2026):
+// - Clause arguments that require an integral-constant-expression accept
+//    C integral constant expressions (macros and enum values).
+// 
+//  Notes:
+//  - Uses integral constant expressions in: collapse, tile, cache (index and slice),
+//   and gang(dim:) to validate compile-time constant handling.
+
 
 #include "acc_testsuite.h"
 #include <openacc.h>

--- a/Tests/acc_integral_constant_expression.c
+++ b/Tests/acc_integral_constant_expression.c
@@ -4,26 +4,14 @@
 // - Clause arguments that require an integral-constant-expression accept
 //    C integral constant expressions (macros and enum values).
 // 
-//  Notes:
-//  T1: collapse() accepts an integral-constant-expression (ICE).
-//   This test uses a macro ICE in collapse() and checks runtime correctness.
-//  
-//  T2: tile() accepts an integral-constant-expression (ICE).
-//   This test uses a macro ICE in tile() and checks runtime correctness.
-//
-//  T3: tile() accepts ICE values (enums/macros).
-//   This test mixes enum + macro ICE in tile() and checks correctness.
-//
-//  T4: cache() indexing accepts an integral-constant-expression (ICE).
-//   This test uses an enum ICE as the cache element index.
-//
-//  T5: cache() subarray slices accept ICE values.
-//   This test uses enum/macro ICE for lower:length in cache().
-//
-//  T6: gang(dim:) accepts an integral-constant-expression (ICE) (valid range 1..3).
-//   This test uses an enum ICE in gang(dim:) and checks runtime correctness.
-// – Some compilers may not support the 'dim:' keyword form yet; keep this as spec conformance coverage.
-//
+// Notes:
+// - T1: collapse() uses a macro ICE.
+// - T2: tile() uses a macro ICE.
+// - T3: tile() mixes enum + macro ICE.
+// - T4: cache() element index uses an enum ICE.
+// - T5: cache() lower:length slice uses ICE values.
+// - T6: gang(dim:) uses an enum ICE (must be 1..3).
+//   Some compilers may not support gang(dim:) yet; keep for spec coverage.
 
 #include "acc_testsuite.h"
 #include <openacc.h>

--- a/Tests/acc_integral_constant_expression.cpp
+++ b/Tests/acc_integral_constant_expression.cpp
@@ -1,0 +1,253 @@
+// acc_integral_constant_expression.cpp
+#include "acc_testsuite.h"
+#include <openacc.h>
+#include <cstdlib>
+#include <cmath>
+#include <cstddef>
+
+// C++ integral constant expressions: constexpr + enum
+static constexpr int ICE_CONST2 = 2;
+static constexpr int ICE_CONST4 = 4;
+enum class E2 : int { V = 2 };
+static constexpr int ICE_LOWER = 3;
+
+static int check_vec_add(const real_t* a, const real_t* b, const real_t* c, int nloc){
+    int err = 0;
+    for(int i=0;i<nloc;i++){
+        if (std::fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+    }
+    return err;
+}
+
+#ifndef T1
+//T1:syntax,collapse-clause,runtime,loop,V:3.4-
+// collapse(2) literal ICE
+int test1(){
+    int err = 0;
+    const int M = 64, N = 16, MN = M*N;
+    real_t *a=(real_t*)std::malloc((size_t)MN*sizeof(real_t));
+    real_t *b=(real_t*)std::malloc((size_t)MN*sizeof(real_t));
+    real_t *c=(real_t*)std::malloc((size_t)MN*sizeof(real_t));
+    if(!a||!b||!c){ std::free(a); std::free(b); std::free(c); return 1; }
+
+    for(int i=0;i<MN;i++){ a[i]=(real_t)i; b[i]=(real_t)(2*i); c[i]=0; }
+
+    #pragma acc data copyin(a[0:MN],b[0:MN]) copyout(c[0:MN])
+    {
+        #pragma acc parallel loop collapse(2)
+        for(int i=0;i<M;i++){
+            for(int j=0;j<N;j++){
+                int idx = i*N + j;
+                c[idx] = a[idx] + b[idx];
+            }
+        }
+    }
+
+    err += check_vec_add(a,b,c,MN);
+    std::free(a); std::free(b); std::free(c);
+    return err;
+}
+#endif
+
+#ifndef T2
+//T2:syntax,collapse-clause,runtime,loop,V:3.4-
+// collapse(ICE_CONST2) constexpr ICE
+int test2(){
+    int err = 0;
+    const int M = 48, N = 12, MN = M*N;
+    real_t *a=(real_t*)std::malloc((size_t)MN*sizeof(real_t));
+    real_t *b=(real_t*)std::malloc((size_t)MN*sizeof(real_t));
+    real_t *c=(real_t*)std::malloc((size_t)MN*sizeof(real_t));
+    if(!a||!b||!c){ std::free(a); std::free(b); std::free(c); return 1; }
+
+    for(int i=0;i<MN;i++){ a[i]=(real_t)(i+2); b[i]=(real_t)(i-1); c[i]=0; }
+
+    #pragma acc data copyin(a[0:MN],b[0:MN]) copyout(c[0:MN])
+    {
+        #pragma acc parallel loop collapse(ICE_CONST2)
+        for(int i=0;i<M;i++){
+            for(int j=0;j<N;j++){
+                int idx = i*N + j;
+                c[idx] = a[idx] + b[idx];
+            }
+        }
+    }
+
+    err += check_vec_add(a,b,c,MN);
+    std::free(a); std::free(b); std::free(c);
+    return err;
+}
+#endif
+
+#ifndef T3
+//T3:syntax,tile-clause,runtime,loop,V:3.4-
+// tile(2) literal ICE
+int test3(){
+    int err = 0;
+    const int M = 256;
+    real_t *a=(real_t*)std::malloc((size_t)M*sizeof(real_t));
+    real_t *c=(real_t*)std::malloc((size_t)M*sizeof(real_t));
+    if(!a||!c){ std::free(a); std::free(c); return 1; }
+
+    for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=0; }
+
+    #pragma acc data copyin(a[0:M]) copyout(c[0:M])
+    {
+        #pragma acc parallel loop tile(2)
+        for(int i=0;i<M;i++){
+            c[i] = a[i] * (real_t)2.0;
+        }
+    }
+
+    for(int i=0;i<M;i++){
+        if (std::fabs(c[i] - a[i]*(real_t)2.0) > PRECISION) err++;
+    }
+    std::free(a); std::free(c);
+    return err;
+}
+#endif
+
+#ifndef T4
+//T4:syntax,tile-clause,runtime,loop,V:3.4-
+// tile(ICE_CONST2, int(E2::V)) constexpr + enum-class ICE
+int test4(){
+    int err = 0;
+    const int M = 64, N = 40, MN = M*N;
+    real_t *a=(real_t*)std::malloc((size_t)MN*sizeof(real_t));
+    real_t *b=(real_t*)std::malloc((size_t)MN*sizeof(real_t));
+    real_t *c=(real_t*)std::malloc((size_t)MN*sizeof(real_t));
+    if(!a||!b||!c){ std::free(a); std::free(b); std::free(c); return 1; }
+
+    for(int i=0;i<MN;i++){ a[i]=(real_t)(i+1); b[i]=(real_t)(3*i); c[i]=0; }
+
+    #pragma acc data copyin(a[0:MN],b[0:MN]) copyout(c[0:MN])
+    {
+        #pragma acc parallel loop tile(ICE_CONST2, (int)E2::V)
+        for(int i=0;i<M;i++){
+            for(int j=0;j<N;j++){
+                int idx = i*N + j;
+                c[idx] = a[idx] + b[idx];
+            }
+        }
+    }
+
+    err += check_vec_add(a,b,c,MN);
+    std::free(a); std::free(b); std::free(c);
+    return err;
+}
+#endif
+
+#ifndef T5
+//T5:syntax,cache-directive,runtime,loop,V:3.4-
+// cache element index uses constexpr ICE
+int test5(){
+    int err = 0;
+    const int M = 512;
+    real_t *a=(real_t*)std::malloc((size_t)M*sizeof(real_t));
+    real_t *c=(real_t*)std::malloc((size_t)M*sizeof(real_t));
+    if(!a||!c){ std::free(a); std::free(c); return 1; }
+
+    for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=0; }
+
+    #pragma acc data copyin(a[0:M]) copyout(c[0:M])
+    {
+        #pragma acc parallel loop
+        for(int i=0;i<M;i++){
+            #pragma acc cache(a[ICE_CONST2])
+            c[i] = a[i] + (real_t)1.0;
+        }
+    }
+
+    for(int i=0;i<M;i++){
+        if (std::fabs(c[i] - (a[i]+(real_t)1.0)) > PRECISION) err++;
+    }
+    std::free(a); std::free(c);
+    return err;
+}
+#endif
+
+#ifndef T6
+//T6:syntax,cache-directive,runtime,loop,V:3.4-
+// cache lower:length uses ICE lower + ICE length
+int test6(){
+    int err = 0;
+    const int M = 512;
+    real_t *a=(real_t*)std::malloc((size_t)M*sizeof(real_t));
+    real_t *c=(real_t*)std::malloc((size_t)M*sizeof(real_t));
+    if(!a||!c){ std::free(a); std::free(c); return 1; }
+
+    for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=a[i]; }
+
+    #pragma acc data copyin(a[0:M]) copy(c[0:M])
+    {
+        #pragma acc parallel loop
+        for(int i=0;i<M;i++){
+            #pragma acc cache(a[ICE_LOWER:ICE_CONST4])
+            c[i] = c[i] + (real_t)2.0;
+        }
+    }
+
+    for(int i=0;i<M;i++){
+        if (std::fabs(c[i] - (a[i]+(real_t)2.0)) > PRECISION) err++;
+    }
+    std::free(a); std::free(c);
+    return err;
+}
+#endif
+
+#ifndef T7
+//T7:syntax,gang-clause,runtime,loop,V:3.4-
+// gang(dim:ICE_CONST2) where dim is an integral constant expression (constexpr), must evaluate to 1..3
+// NOTE: Some compilers may not support the 'dim:' keyword form yet; keep this as spec conformance coverage.
+int test7(){
+    int err = 0;
+    const int M = 512;
+    real_t *a=(real_t*)std::malloc((size_t)M*sizeof(real_t));
+    real_t *c=(real_t*)std::malloc((size_t)M*sizeof(real_t));
+    if(!a||!c){ std::free(a); std::free(c); return 1; }
+
+    for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=0; }
+
+    #pragma acc data copyin(a[0:M]) copyout(c[0:M])
+    {
+        #pragma acc parallel loop gang(dim:ICE_CONST2)
+        for(int i=0;i<M;i++){
+            c[i] = a[i] * (real_t)2.0;
+        }
+    }
+
+    for(int i=0;i<M;i++){
+        if (std::fabs(c[i] - a[i]*(real_t)2.0) > PRECISION) err++;
+    }
+
+    std::free(a); std::free(c);
+    return err;
+}
+#endif
+
+
+int main(){
+    int failcode=0, failed;
+#ifndef T1
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test1(); if(failed) failcode|=(1<<0);
+#endif
+#ifndef T2
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test2(); if(failed) failcode|=(1<<1);
+#endif
+#ifndef T3
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test3(); if(failed) failcode|=(1<<2);
+#endif
+#ifndef T4
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test4(); if(failed) failcode|=(1<<3);
+#endif
+#ifndef T5
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test5(); if(failed) failcode|=(1<<4);
+#endif
+#ifndef T6
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test6(); if(failed) failcode|=(1<<5);
+#endif
+#ifndef T7
+    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test7(); if(failed) failcode|=(1<<6);
+#endif
+    return failcode;
+}

--- a/Tests/acc_integral_constant_expression.cpp
+++ b/Tests/acc_integral_constant_expression.cpp
@@ -27,8 +27,6 @@ enum class E2 : int { V = 2 };
 static constexpr int ICE_LOWER = 3;
 
 #ifndef T1
-//T1:syntax,collapse-clause,runtime,loop,V:3.4-
-// collapse(ICE_CONST2) constexpr ICE
 int test1(){
     int err = 0;
     const int M = 48, N = 12, MN = M*N;
@@ -70,8 +68,6 @@ int test1(){
 }
 #endif
 #ifndef T2
-//T2:syntax,tile-clause,runtime,loop,V:3.4-
-// tile(ICE_CONST2) constexpr ICE
 int test2(){
     int err = 0;
     const int M = 256;
@@ -106,8 +102,6 @@ int test2(){
 }
 #endif
 #ifndef T3
-//T3:syntax,tile-clause,runtime,loop,V:3.4-
-// tile(ICE_CONST2, int(E2::V)) constexpr + enum-class ICE
 int test3(){
     int err = 0;
     const int M = 64, N = 40, MN = M*N;
@@ -149,8 +143,6 @@ int test3(){
 }
 #endif
 #ifndef T4
-//T4:syntax,cache-directive,runtime,loop,V:3.4-
-// cache element index uses constexpr ICE
 int test4(){
     int err = 0;
     const int M = 512;
@@ -188,8 +180,6 @@ int test4(){
 }
 #endif
 #ifndef T5
-//T5:syntax,cache-directive,runtime,loop,V:3.4-
-// cache lower:length uses ICE lower + ICE length
 int test5(){
     int err = 0;
     const int M = 512;
@@ -227,9 +217,6 @@ int test5(){
 }
 #endif
 #ifndef T6
-//T6:syntax,gang-clause,runtime,loop,V:3.4-
-// gang(dim:ICE_CONST2) where dim is an integral constant expression (constexpr), must evaluate to 1..3
-// NOTE: Some compilers may not support the 'dim:' keyword form yet; keep this as spec conformance coverage.
 int test6(){
     int err = 0;
     const int M = 512;

--- a/Tests/acc_integral_constant_expression.cpp
+++ b/Tests/acc_integral_constant_expression.cpp
@@ -4,9 +4,26 @@
 // - Clause arguments that require an integral-constant-expression accept
 //   C++ integral constant expressions (constexpr values and enum values).
 //
-// Notes:
-// - Uses integral constant expressions in: collapse, tile, cache (index and slice),
-//   and gang(dim:) to validate compile-time constant handling.
+//  Notes:
+//  T1: collapse() accepts an integral-constant-expression (ICE).
+//   This test uses a macro ICE in collapse() and checks runtime correctness.
+//  
+//  T2: tile() accepts an integral-constant-expression (ICE).
+//   This test uses a macro ICE in tile() and checks runtime correctness.
+//
+//  T3: tile() accepts ICE values (enums/macros).
+//   This test mixes enum + macro ICE in tile() and checks correctness.
+//
+//  T4: cache() indexing accepts an integral-constant-expression (ICE).
+//   This test uses an enum ICE as the cache element index.
+//
+//  T5: cache() subarray slices accept ICE values.
+//   This test uses enum/macro ICE for lower:length in cache().
+//
+//  T6: gang(dim:) accepts an integral-constant-expression (ICE) (valid range 1..3).
+//   This test uses an enum ICE in gang(dim:) and checks runtime correctness.
+// – Some compilers may not support the 'dim:' keyword form yet; keep this as spec conformance coverage.
+//
 
 
 #include "acc_testsuite.h"
@@ -35,7 +52,13 @@ int test1(){
         std::free(c);
         return 1;
     }
-    for(int i=0;i<MN;i++){ a[i]=(real_t)(i+2); b[i]=(real_t)(i-1); c[i]=0; }
+    
+    for(int i=0;i<MN;i++){ 
+        a[i]=(real_t)(i+2); 
+        b[i]=(real_t)(i-1);
+        c[i]=0;
+    }
+    
     #pragma acc data copyin(a[0:MN],b[0:MN]) copyout(c[0:MN])
     {
         #pragma acc parallel loop collapse(ICE_CONST2)
@@ -47,7 +70,9 @@ int test1(){
         }
     }
     for(int i=0;i<MN;i++){
-        if (std::fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+        if (std::fabs(c[i] - (a[i] + b[i])) > PRECISION){
+            err++;
+        }
     }
     std::free(a);
     std::free(b);
@@ -68,7 +93,11 @@ int test2(){
         std::free(c);
         return 1;
     }
-    for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=0; }
+    
+    for(int i=0;i<M;i++){
+        a[i]=(real_t)i; c[i]=0;
+    }
+    
     #pragma acc data copyin(a[0:M]) copyout(c[0:M])
     {
         #pragma acc parallel loop tile(ICE_CONST2)
@@ -76,8 +105,11 @@ int test2(){
             c[i] = a[i] * (real_t)2.0;
         }
     }
+    
     for(int i=0;i<M;i++){
-        if (std::fabs(c[i] - a[i]*(real_t)2.0) > PRECISION) err++;
+        if (std::fabs(c[i] - a[i]*(real_t)2.0) > PRECISION){
+            err++;
+        }
     }
     std::free(a);
     std::free(c);
@@ -99,7 +131,13 @@ int test3(){
         std::free(c);
         return 1;
     }
-    for(int i=0;i<MN;i++){ a[i]=(real_t)(i+1); b[i]=(real_t)(3*i); c[i]=0; }
+    
+    for(int i=0;i<MN;i++){
+        a[i]=(real_t)(i+1);
+        b[i]=(real_t)(3*i); 
+        c[i]=0; 
+    }
+    
     #pragma acc data copyin(a[0:MN],b[0:MN]) copyout(c[0:MN])
     {
         #pragma acc parallel loop tile(ICE_CONST2, (int)E2::V)
@@ -111,7 +149,9 @@ int test3(){
         }
     }
     for(int i=0;i<MN;i++){
-        if (std::fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+        if (std::fabs(c[i] - (a[i] + b[i])) > PRECISION){
+            err++;
+        }
     }
     std::free(a);
     std::free(b);
@@ -132,7 +172,12 @@ int test4(){
         std::free(c);
         return 1;
     }
-    for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=0; }
+    
+    for(int i=0;i<M;i++){
+        a[i]=(real_t)i;
+        c[i]=0; 
+    }
+    
     #pragma acc data copyin(a[0:M]) copyout(c[0:M])
     {
         #pragma acc parallel loop
@@ -141,9 +186,13 @@ int test4(){
             c[i] = a[i] + (real_t)1.0;
         }
     }
+    
     for(int i=0;i<M;i++){
-        if (std::fabs(c[i] - (a[i]+(real_t)1.0)) > PRECISION) err++;
+        if (std::fabs(c[i] - (a[i]+(real_t)1.0)) > PRECISION){
+            err++;
+        }
     }
+    
     std::free(a);
     std::free(c);
     return err;
@@ -162,7 +211,12 @@ int test5(){
         std::free(c);
         return 1;
     }
-    for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=a[i]; }
+    
+    for(int i=0;i<M;i++){
+        a[i]=(real_t)i; 
+        c[i]=a[i]; 
+    }
+    
     #pragma acc data copyin(a[0:M]) copy(c[0:M])
     {
         #pragma acc parallel loop
@@ -171,9 +225,13 @@ int test5(){
             c[i] = c[i] + (real_t)2.0;
         }
     }
+    
     for(int i=0;i<M;i++){
-        if (std::fabs(c[i] - (a[i]+(real_t)2.0)) > PRECISION) err++;
+        if (std::fabs(c[i] - (a[i]+(real_t)2.0)) > PRECISION){
+            err++;
+        }
     }
+    
     std::free(a);
     std::free(c);
     return err;
@@ -193,7 +251,12 @@ int test6(){
         std::free(c);
         return 1;
     }
-    for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=0; }
+    
+    for(int i=0;i<M;i++){
+        a[i]=(real_t)i;
+        c[i]=0; 
+    }
+    
     #pragma acc data copyin(a[0:M]) copyout(c[0:M])
     {
         #pragma acc parallel loop gang(dim:ICE_CONST2)
@@ -201,9 +264,13 @@ int test6(){
             c[i] = a[i] * (real_t)2.0;
         }
     }
+    
     for(int i=0;i<M;i++){
-        if (std::fabs(c[i] - a[i]*(real_t)2.0) > PRECISION) err++;
+        if (std::fabs(c[i] - a[i]*(real_t)2.0) > PRECISION){
+            err++;
+        }
     }
+    
     std::free(a);
     std::free(c);
     return err;
@@ -212,22 +279,58 @@ int test6(){
 int main(){
     int failcode=0, failed;
 #ifndef T1
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test1(); if(failed) failcode|=(1<<0);
+    failed=0; 
+    for(int i=0;i<NUM_TEST_CALLS;i++){
+        failed+=test1(); 
+    }
+    if(failed){
+        failcode|=(1<<0);
+    }
 #endif
 #ifndef T2
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test2(); if(failed) failcode|=(1<<1);
+    failed=0; 
+    for(int i=0;i<NUM_TEST_CALLS;i++){
+        failed+=test2(); 
+    }
+    if(failed){
+        failcode|=(1<<1);
+    }
 #endif
 #ifndef T3
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test3(); if(failed) failcode|=(1<<2);
+    failed=0; 
+    for(int i=0;i<NUM_TEST_CALLS;i++){
+        failed+=test3(); 
+    }
+    if(failed){
+        failcode|=(1<<2);
+    }
 #endif
 #ifndef T4
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test4(); if(failed) failcode|=(1<<3);
+    failed=0; 
+    for(int i=0;i<NUM_TEST_CALLS;i++){
+        failed+=test4(); 
+    }
+    if(failed){
+        failcode|=(1<<3);
+    }
 #endif
 #ifndef T5
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test5(); if(failed) failcode|=(1<<4);
+    failed=0; 
+    for(int i=0;i<NUM_TEST_CALLS;i++){
+        failed+=test5(); 
+    }
+    if(failed){
+        failcode|=(1<<4);
+    }
 #endif
 #ifndef T6
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test6(); if(failed) failcode|=(1<<5);
+    failed=0; 
+    for(int i=0;i<NUM_TEST_CALLS;i++){
+        failed+=test6();
+    }
+    if(failed){
+        failcode|=(1<<5);
+    }
 #endif
     return failcode;
 }

--- a/Tests/acc_integral_constant_expression.cpp
+++ b/Tests/acc_integral_constant_expression.cpp
@@ -1,7 +1,13 @@
 // acc_integral_constant_expression.cpp
-// Validates that C++ integral constant expressions (constexpr values and enums) are accepted in OpenACC clause arguments where the spec requires an integral-constant-expression.
-// Exercises constant expressions in collapse, tile, cache indexing/slices, and gang(dim:) to confirm correct parsing and conformance to the spec’s compile-time constant requirement.
-// Tests check correctness by running device loops and comparing computed results against expected host values.
+//
+// Feature under test (OpenACC 3.4, Section 1.6, Feb 2026):
+// - Clause arguments that require an integral-constant-expression accept
+//   C++ integral constant expressions (constexpr values and enum values).
+//
+// Notes:
+// - Uses integral constant expressions in: collapse, tile, cache (index and slice),
+//   and gang(dim:) to validate compile-time constant handling.
+
 
 #include "acc_testsuite.h"
 #include <openacc.h>

--- a/Tests/acc_integral_constant_expression.cpp
+++ b/Tests/acc_integral_constant_expression.cpp
@@ -4,25 +4,14 @@
 // - Clause arguments that require an integral-constant-expression accept
 //   C++ integral constant expressions (constexpr values and enum values).
 //
-//  Notes:
-//  T1: collapse() accepts an integral-constant-expression (ICE).
-//   This test uses a macro ICE in collapse() and checks runtime correctness.
-//  
-//  T2: tile() accepts an integral-constant-expression (ICE).
-//   This test uses a macro ICE in tile() and checks runtime correctness.
-//
-//  T3: tile() accepts ICE values (enums/macros).
-//   This test mixes enum + macro ICE in tile() and checks correctness.
-//
-//  T4: cache() indexing accepts an integral-constant-expression (ICE).
-//   This test uses an enum ICE as the cache element index.
-//
-//  T5: cache() subarray slices accept ICE values.
-//   This test uses enum/macro ICE for lower:length in cache().
-//
-//  T6: gang(dim:) accepts an integral-constant-expression (ICE) (valid range 1..3).
-//   This test uses an enum ICE in gang(dim:) and checks runtime correctness.
-// – Some compilers may not support the 'dim:' keyword form yet; keep this as spec conformance coverage.
+// Notes:
+// - T1: collapse() uses a constexpr ICE.
+// - T2: tile() uses a constexpr ICE.
+// - T3: tile() mixes constexpr + enum ICE.
+// - T4: cache() element index uses a constexpr ICE.
+// - T5: cache() lower:length slice uses constexpr ICE values.
+// - T6: gang(dim:) uses a constexpr ICE (must be 1..3).
+//   Some compilers may not support gang(dim:) yet; keep for spec coverage.
 //
 
 

--- a/Tests/acc_integral_constant_expression.cpp
+++ b/Tests/acc_integral_constant_expression.cpp
@@ -1,67 +1,35 @@
 // acc_integral_constant_expression.cpp
+// Validates that C++ integral constant expressions (constexpr values and enums) are accepted in OpenACC clause arguments where the spec requires an integral-constant-expression.
+// Exercises constant expressions in collapse, tile, cache indexing/slices, and gang(dim:) to confirm correct parsing and conformance to the spec’s compile-time constant requirement.
+// Tests check correctness by running device loops and comparing computed results against expected host values.
+
 #include "acc_testsuite.h"
 #include <openacc.h>
 #include <cstdlib>
 #include <cmath>
 #include <cstddef>
-
 // C++ integral constant expressions: constexpr + enum
 static constexpr int ICE_CONST2 = 2;
 static constexpr int ICE_CONST4 = 4;
 enum class E2 : int { V = 2 };
 static constexpr int ICE_LOWER = 3;
 
-static int check_vec_add(const real_t* a, const real_t* b, const real_t* c, int nloc){
-    int err = 0;
-    for(int i=0;i<nloc;i++){
-        if (std::fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
-    }
-    return err;
-}
-
 #ifndef T1
 //T1:syntax,collapse-clause,runtime,loop,V:3.4-
-// collapse(2) literal ICE
-int test1(){
-    int err = 0;
-    const int M = 64, N = 16, MN = M*N;
-    real_t *a=(real_t*)std::malloc((size_t)MN*sizeof(real_t));
-    real_t *b=(real_t*)std::malloc((size_t)MN*sizeof(real_t));
-    real_t *c=(real_t*)std::malloc((size_t)MN*sizeof(real_t));
-    if(!a||!b||!c){ std::free(a); std::free(b); std::free(c); return 1; }
-
-    for(int i=0;i<MN;i++){ a[i]=(real_t)i; b[i]=(real_t)(2*i); c[i]=0; }
-
-    #pragma acc data copyin(a[0:MN],b[0:MN]) copyout(c[0:MN])
-    {
-        #pragma acc parallel loop collapse(2)
-        for(int i=0;i<M;i++){
-            for(int j=0;j<N;j++){
-                int idx = i*N + j;
-                c[idx] = a[idx] + b[idx];
-            }
-        }
-    }
-
-    err += check_vec_add(a,b,c,MN);
-    std::free(a); std::free(b); std::free(c);
-    return err;
-}
-#endif
-
-#ifndef T2
-//T2:syntax,collapse-clause,runtime,loop,V:3.4-
 // collapse(ICE_CONST2) constexpr ICE
-int test2(){
+int test1(){
     int err = 0;
     const int M = 48, N = 12, MN = M*N;
     real_t *a=(real_t*)std::malloc((size_t)MN*sizeof(real_t));
     real_t *b=(real_t*)std::malloc((size_t)MN*sizeof(real_t));
     real_t *c=(real_t*)std::malloc((size_t)MN*sizeof(real_t));
-    if(!a||!b||!c){ std::free(a); std::free(b); std::free(c); return 1; }
-
+    if(!a||!b||!c){
+        std::free(a);
+        std::free(b);
+        std::free(c);
+        return 1;
+    }
     for(int i=0;i<MN;i++){ a[i]=(real_t)(i+2); b[i]=(real_t)(i-1); c[i]=0; }
-
     #pragma acc data copyin(a[0:MN],b[0:MN]) copyout(c[0:MN])
     {
         #pragma acc parallel loop collapse(ICE_CONST2)
@@ -72,54 +40,60 @@ int test2(){
             }
         }
     }
-
-    err += check_vec_add(a,b,c,MN);
-    std::free(a); std::free(b); std::free(c);
+    for(int i=0;i<MN;i++){
+        if (std::fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+    }
+    std::free(a);
+    std::free(b);
+    std::free(c);
     return err;
 }
 #endif
-
-#ifndef T3
-//T3:syntax,tile-clause,runtime,loop,V:3.4-
-// tile(2) literal ICE
-int test3(){
+#ifndef T2
+//T2:syntax,tile-clause,runtime,loop,V:3.4-
+// tile(ICE_CONST2) constexpr ICE
+int test2(){
     int err = 0;
     const int M = 256;
     real_t *a=(real_t*)std::malloc((size_t)M*sizeof(real_t));
     real_t *c=(real_t*)std::malloc((size_t)M*sizeof(real_t));
-    if(!a||!c){ std::free(a); std::free(c); return 1; }
-
+    if(!a||!c){
+        std::free(a);
+        std::free(c);
+        return 1;
+    }
     for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=0; }
-
     #pragma acc data copyin(a[0:M]) copyout(c[0:M])
     {
-        #pragma acc parallel loop tile(2)
+        #pragma acc parallel loop tile(ICE_CONST2)
         for(int i=0;i<M;i++){
             c[i] = a[i] * (real_t)2.0;
         }
     }
-
     for(int i=0;i<M;i++){
         if (std::fabs(c[i] - a[i]*(real_t)2.0) > PRECISION) err++;
     }
-    std::free(a); std::free(c);
+    std::free(a);
+    std::free(c);
     return err;
 }
 #endif
-
-#ifndef T4
-//T4:syntax,tile-clause,runtime,loop,V:3.4-
+#ifndef T3
+//T3:syntax,tile-clause,runtime,loop,V:3.4-
 // tile(ICE_CONST2, int(E2::V)) constexpr + enum-class ICE
-int test4(){
+int test3(){
     int err = 0;
     const int M = 64, N = 40, MN = M*N;
     real_t *a=(real_t*)std::malloc((size_t)MN*sizeof(real_t));
     real_t *b=(real_t*)std::malloc((size_t)MN*sizeof(real_t));
     real_t *c=(real_t*)std::malloc((size_t)MN*sizeof(real_t));
-    if(!a||!b||!c){ std::free(a); std::free(b); std::free(c); return 1; }
-
+    if(!a||!b||!c){
+        std::free(a);
+        std::free(b);
+        std::free(c);
+        return 1;
+    }
     for(int i=0;i<MN;i++){ a[i]=(real_t)(i+1); b[i]=(real_t)(3*i); c[i]=0; }
-
     #pragma acc data copyin(a[0:MN],b[0:MN]) copyout(c[0:MN])
     {
         #pragma acc parallel loop tile(ICE_CONST2, (int)E2::V)
@@ -130,25 +104,29 @@ int test4(){
             }
         }
     }
-
-    err += check_vec_add(a,b,c,MN);
-    std::free(a); std::free(b); std::free(c);
+    for(int i=0;i<MN;i++){
+        if (std::fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+    }
+    std::free(a);
+    std::free(b);
+    std::free(c);
     return err;
 }
 #endif
-
-#ifndef T5
-//T5:syntax,cache-directive,runtime,loop,V:3.4-
+#ifndef T4
+//T4:syntax,cache-directive,runtime,loop,V:3.4-
 // cache element index uses constexpr ICE
-int test5(){
+int test4(){
     int err = 0;
     const int M = 512;
     real_t *a=(real_t*)std::malloc((size_t)M*sizeof(real_t));
     real_t *c=(real_t*)std::malloc((size_t)M*sizeof(real_t));
-    if(!a||!c){ std::free(a); std::free(c); return 1; }
-
+    if(!a||!c){
+        std::free(a);
+        std::free(c);
+        return 1;
+    }
     for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=0; }
-
     #pragma acc data copyin(a[0:M]) copyout(c[0:M])
     {
         #pragma acc parallel loop
@@ -157,27 +135,28 @@ int test5(){
             c[i] = a[i] + (real_t)1.0;
         }
     }
-
     for(int i=0;i<M;i++){
         if (std::fabs(c[i] - (a[i]+(real_t)1.0)) > PRECISION) err++;
     }
-    std::free(a); std::free(c);
+    std::free(a);
+    std::free(c);
     return err;
 }
 #endif
-
-#ifndef T6
-//T6:syntax,cache-directive,runtime,loop,V:3.4-
+#ifndef T5
+//T5:syntax,cache-directive,runtime,loop,V:3.4-
 // cache lower:length uses ICE lower + ICE length
-int test6(){
+int test5(){
     int err = 0;
     const int M = 512;
     real_t *a=(real_t*)std::malloc((size_t)M*sizeof(real_t));
     real_t *c=(real_t*)std::malloc((size_t)M*sizeof(real_t));
-    if(!a||!c){ std::free(a); std::free(c); return 1; }
-
+    if(!a||!c){
+        std::free(a);
+        std::free(c);
+        return 1;
+    }
     for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=a[i]; }
-
     #pragma acc data copyin(a[0:M]) copy(c[0:M])
     {
         #pragma acc parallel loop
@@ -186,28 +165,29 @@ int test6(){
             c[i] = c[i] + (real_t)2.0;
         }
     }
-
     for(int i=0;i<M;i++){
         if (std::fabs(c[i] - (a[i]+(real_t)2.0)) > PRECISION) err++;
     }
-    std::free(a); std::free(c);
+    std::free(a);
+    std::free(c);
     return err;
 }
 #endif
-
-#ifndef T7
-//T7:syntax,gang-clause,runtime,loop,V:3.4-
+#ifndef T6
+//T6:syntax,gang-clause,runtime,loop,V:3.4-
 // gang(dim:ICE_CONST2) where dim is an integral constant expression (constexpr), must evaluate to 1..3
 // NOTE: Some compilers may not support the 'dim:' keyword form yet; keep this as spec conformance coverage.
-int test7(){
+int test6(){
     int err = 0;
     const int M = 512;
     real_t *a=(real_t*)std::malloc((size_t)M*sizeof(real_t));
     real_t *c=(real_t*)std::malloc((size_t)M*sizeof(real_t));
-    if(!a||!c){ std::free(a); std::free(c); return 1; }
-
+    if(!a||!c){
+        std::free(a);
+        std::free(c);
+        return 1;
+    }
     for(int i=0;i<M;i++){ a[i]=(real_t)i; c[i]=0; }
-
     #pragma acc data copyin(a[0:M]) copyout(c[0:M])
     {
         #pragma acc parallel loop gang(dim:ICE_CONST2)
@@ -215,17 +195,14 @@ int test7(){
             c[i] = a[i] * (real_t)2.0;
         }
     }
-
     for(int i=0;i<M;i++){
         if (std::fabs(c[i] - a[i]*(real_t)2.0) > PRECISION) err++;
     }
-
-    std::free(a); std::free(c);
+    std::free(a);
+    std::free(c);
     return err;
 }
 #endif
-
-
 int main(){
     int failcode=0, failed;
 #ifndef T1
@@ -245,9 +222,6 @@ int main(){
 #endif
 #ifndef T6
     failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test6(); if(failed) failcode|=(1<<5);
-#endif
-#ifndef T7
-    failed=0; for(int i=0;i<NUM_TEST_CALLS;i++) failed+=test7(); if(failed) failcode|=(1<<6);
 #endif
     return failcode;
 }


### PR DESCRIPTION
### Feature:
– This PR adds validation and verification tests for the OpenACC 3.4 clarification that introduces the term integral-constant-expression and aligns its meaning with the base languages (see §1.6).
– An integral constant expression is a compile-time constant integer expression as defined by the host language (C, C++, Fortran), and is required by the specification in several clauses and directives

### What the tests validate:
The tests ensure that valid compile-time integer constants are accepted by compilers when used in positions where the OpenACC specification explicitly requires an integral constant expression, and that the associated constructs execute correctly at runtime.

### Coverage includes the following spec locations:
- Collapse clause (§2.9.1)
Argument must be a positive, non-zero integral constant expression
- Tile clause (§2.9.8)
Each tile size must be a positive, non-zero integral-constant-expression (or *).
- Cache directive (§2.10)
Array element indices, lower bounds, and lengths may include integral-constant-expressions.
- Gang clause – dim: argument (§2.9.2)
The dim argument must be an integral-constant-expression evaluating to 1, 2, or 3.

### Test design:
Each language file contains seven tests (T1-T6) that:
- Use language appropriate forms of ICE
       •C: integer macros and enum constants
       • C++: constexpr values and (scoped) enums
       • Fortran: integer PARAMETER expressions
- Place ICE values directly into spec-mandated positions
- perform a runtime computation check (vector add / scale) to confirm the construct executes correctly, not just parse

### Test mapping
- T1: collapse clause (arithmetic ICE forms)
- T2: tile clause (single tile ICE)
- T3: tile clause (multi-dimensional ICE lists)
- T4: cache directive (ICE used in element index)
- T5: cache directive (ICE used in lower/length ranges)
- T6: gang(dim: ICE)

### Notes on cache behavior
cache is a performance hint and may be ignored by implementations. The tests primarily validate syntax acceptance of integral-constant-expressions in cache subscript/range forms. In all three language versions (C, C++, and Fortran), the cache directive is placed inside the actual parallel loop body to maintain consistent structure across implementations. The cached array section or element uses integral-constant-expressions exactly where permitted by §2.10.

### Expected compiler behavior and results
•NVHPC 25.5: Passes T1-T6
•GCC 15.2.0: Passes T1-T5; fails T6 (parser rejects "dim:" keyword form)
•Cray 18.0.0: Passes T1-T5 (may emit cache warnings); fails T6 (parser rejects "dim:" keyword form)

Failures in T6 occur at directive parse time, before ICE semantic checking, and indicate incomplete support for the dim: keyword syntax—not an invalid test or misuse of ICE. 

 