### PR TITLE
Validate _Pragma support for directives in C and C++

### DIFF
--- a/Tests/acc_pragma_operator.c
+++ b/Tests/acc_pragma_operator.c
@@ -1,0 +1,114 @@
+// acc_pragma_operator.c
+// Validates that the C _Pragma operator form is supported for OpenACC directives.
+// Uses only _Pragma("acc ...") (no helper macros) and verifies correct runtime results.
+
+#include "acc_testsuite.h"
+#include <openacc.h>
+#include <stdlib.h>
+#include <math.h>
+
+#ifndef T1
+//T1:runtime,syntax,pragma,construct-independent,V:3.4-
+// Use _Pragma form for data/parallel/loop and verify computation
+int test1(void){
+    int err = 0;
+    srand(SEED);
+
+    real_t *a = (real_t*)malloc(n * sizeof(real_t));
+    real_t *b = (real_t*)malloc(n * sizeof(real_t));
+    real_t *c = (real_t*)malloc(n * sizeof(real_t));
+
+    for (int i = 0; i < n; ++i){
+        a[i] = rand() / (real_t)(RAND_MAX / 10);
+        b[i] = rand() / (real_t)(RAND_MAX / 10);
+        c[i] = 0.0;
+    }
+
+    _Pragma("acc data copyin(a[0:n], b[0:n]) copy(c[0:n])")
+    {
+        _Pragma("acc parallel")
+        {
+            _Pragma("acc loop")
+            for (int i = 0; i < n; ++i){
+                c[i] = a[i] + b[i];
+            }
+        }
+    }
+
+    for (int i = 0; i < n; ++i){
+        if (fabs(c[i] - (a[i] + b[i])) > PRECISION){
+            err += 1;
+        }
+    }
+
+    free(a);
+    free(b);
+    free(c);
+    return err;
+}
+#endif
+
+#ifndef T2
+//T2:runtime,syntax,pragma,construct-independent,V:3.4-
+// Use _Pragma form for enter/exit data directives
+int test2(void){
+    int err = 0;
+    srand(SEED);
+
+    real_t *a = (real_t*)malloc(n * sizeof(real_t));
+    real_t *b = (real_t*)malloc(n * sizeof(real_t));
+    real_t *c = (real_t*)malloc(n * sizeof(real_t));
+
+    for (int i = 0; i < n; ++i){
+        a[i] = rand() / (real_t)(RAND_MAX / 10);
+        b[i] = rand() / (real_t)(RAND_MAX / 10);
+        c[i] = 0.0;
+    }
+
+    _Pragma("acc enter data copyin(a[0:n], b[0:n]) create(c[0:n])")
+
+    _Pragma("acc parallel present(a[0:n], b[0:n], c[0:n])")
+    {
+        _Pragma("acc loop")
+        for (int i = 0; i < n; ++i){
+            c[i] = (real_t)2.0 * a[i] - b[i];
+        }
+    }
+
+    _Pragma("acc exit data copyout(c[0:n]) delete(a[0:n], b[0:n])")
+
+    for (int i = 0; i < n; ++i){
+        if (fabs(c[i] - ((real_t)2.0 * a[i] - b[i])) > PRECISION){
+            err += 1;
+        }
+    }
+
+    free(a);
+    free(b);
+    free(c);
+    return err;
+}
+#endif
+
+int main(void){
+    int failcode = 0;
+    int failed;
+
+#ifndef T1
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test1();
+    }
+    if (failed != 0) failcode |= (1 << 0);
+#endif
+
+#ifndef T2
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test2();
+    }
+    if (failed != 0) failcode |= (1 << 1);
+#endif
+
+    return failcode;
+}

--- a/Tests/acc_pragma_operator.c
+++ b/Tests/acc_pragma_operator.c
@@ -15,8 +15,6 @@
 #include <math.h>
 
 #ifndef T1
-//T1:runtime,syntax,pragma,construct-independent,V:3.4-
-// Use _Pragma form for data/parallel/loop and verify computation
 int test1(void){
     int err = 0;
     srand(SEED);
@@ -56,8 +54,6 @@ int test1(void){
 #endif
 
 #ifndef T2
-//T2:runtime,syntax,pragma,construct-independent,V:3.4-
-// Use _Pragma form for enter/exit data directives
 int test2(void){
     int err = 0;
     srand(SEED);

--- a/Tests/acc_pragma_operator.c
+++ b/Tests/acc_pragma_operator.c
@@ -1,6 +1,13 @@
 // acc_pragma_operator.c
-// Validates that the C _Pragma operator form is supported for OpenACC directives.
-// Uses only _Pragma("acc ...") (no helper macros) and verifies correct runtime results.
+//
+// Feature under test (OpenACC 3.4, Section 2.1, February 2026):
+// - In C, OpenACC directives may be expressed using either
+//   #pragma acc ... or the equivalent _Pragma("acc ...") operator form.
+//
+// Notes:
+// - These tests use only the _Pragma("acc ...") form.
+// - Structured (data/parallel/loop) and executable (enter/exit data)
+//   directives are exercised.
 
 #include "acc_testsuite.h"
 #include <openacc.h>

--- a/Tests/acc_pragma_operator.c
+++ b/Tests/acc_pragma_operator.c
@@ -5,9 +5,9 @@
 //   #pragma acc ... or the equivalent _Pragma("acc ...") operator form.
 //
 // Notes:
-// - These tests use only the _Pragma("acc ...") form.
-// - Structured (data/parallel/loop) and executable (enter/exit data)
-//   directives are exercised.
+// - T1: Uses _Pragma for data + parallel + loop and checks computation.
+// - T2: Uses _Pragma for enter data / exit data and checks computation.
+//
 
 #include "acc_testsuite.h"
 #include <openacc.h>
@@ -106,7 +106,9 @@ int main(void){
     for (int i = 0; i < NUM_TEST_CALLS; ++i){
         failed += test1();
     }
-    if (failed != 0) failcode |= (1 << 0);
+    if (failed != 0){
+        failcode |= (1 << 0);
+    }
 #endif
 
 #ifndef T2
@@ -114,7 +116,9 @@ int main(void){
     for (int i = 0; i < NUM_TEST_CALLS; ++i){
         failed += test2();
     }
-    if (failed != 0) failcode |= (1 << 1);
+    if (failed != 0){
+        failcode |= (1 << 1);
+    }
 #endif
 
     return failcode;

--- a/Tests/acc_pragma_operator.cpp
+++ b/Tests/acc_pragma_operator.cpp
@@ -16,8 +16,6 @@
 #include <cmath>
 
 #ifndef T1
-//T1:runtime,syntax,pragma,construct-independent,V:3.4-
-// Use _Pragma form for data/parallel/loop and verify computation
 int test1(){
     int err = 0;
     srand(SEED);
@@ -57,8 +55,6 @@ int test1(){
 #endif
 
 #ifndef T2
-//T2:runtime,syntax,pragma,construct-independent,V:3.4-
-// Use _Pragma form for enter/exit data directives
 int test2(){
     int err = 0;
     srand(SEED);

--- a/Tests/acc_pragma_operator.cpp
+++ b/Tests/acc_pragma_operator.cpp
@@ -1,6 +1,14 @@
 // acc_pragma_operator.cpp
-// Validates that the C++ _Pragma operator form is supported for OpenACC directives.
-// Uses only _Pragma("acc ...") (no helper macros) and verifies correct runtime results.
+//
+// Feature under test (OpenACC 3.4, Section 2.1, February 2026):
+// - In C++, OpenACC directives may be expressed using either
+//   #pragma acc ... or the equivalent _Pragma("acc ...") operator form.
+//
+// Notes:
+// - These tests use only the _Pragma("acc ...") form.
+// - Structured (data/parallel/loop) and executable (enter/exit data)
+//   directives are exercised.
+
 
 #include "acc_testsuite.h"
 #include <openacc.h>

--- a/Tests/acc_pragma_operator.cpp
+++ b/Tests/acc_pragma_operator.cpp
@@ -1,0 +1,114 @@
+// acc_pragma_operator.cpp
+// Validates that the C++ _Pragma operator form is supported for OpenACC directives.
+// Uses only _Pragma("acc ...") (no helper macros) and verifies correct runtime results.
+
+#include "acc_testsuite.h"
+#include <openacc.h>
+#include <cstdlib>
+#include <cmath>
+
+#ifndef T1
+//T1:runtime,syntax,pragma,construct-independent,V:3.4-
+// Use _Pragma form for data/parallel/loop and verify computation
+int test1(){
+    int err = 0;
+    srand(SEED);
+
+    real_t *a = new real_t[n];
+    real_t *b = new real_t[n];
+    real_t *c = new real_t[n];
+
+    for (int i = 0; i < n; ++i){
+        a[i] = rand() / (real_t)(RAND_MAX / 10);
+        b[i] = rand() / (real_t)(RAND_MAX / 10);
+        c[i] = 0.0;
+    }
+
+    _Pragma("acc data copyin(a[0:n], b[0:n]) copy(c[0:n])")
+    {
+        _Pragma("acc parallel")
+        {
+            _Pragma("acc loop")
+            for (int i = 0; i < n; ++i){
+                c[i] = a[i] + b[i];
+            }
+        }
+    }
+
+    for (int i = 0; i < n; ++i){
+        if (fabs(c[i] - (a[i] + b[i])) > PRECISION){
+            err += 1;
+        }
+    }
+
+    delete [] a;
+    delete [] b;
+    delete [] c;
+    return err;
+}
+#endif
+
+#ifndef T2
+//T2:runtime,syntax,pragma,construct-independent,V:3.4-
+// Use _Pragma form for enter/exit data directives
+int test2(){
+    int err = 0;
+    srand(SEED);
+
+    real_t *a = new real_t[n];
+    real_t *b = new real_t[n];
+    real_t *c = new real_t[n];
+
+    for (int i = 0; i < n; ++i){
+        a[i] = rand() / (real_t)(RAND_MAX / 10);
+        b[i] = rand() / (real_t)(RAND_MAX / 10);
+        c[i] = 0.0;
+    }
+
+    _Pragma("acc enter data copyin(a[0:n], b[0:n]) create(c[0:n])")
+
+    _Pragma("acc parallel present(a[0:n], b[0:n], c[0:n])")
+    {
+        _Pragma("acc loop")
+        for (int i = 0; i < n; ++i){
+            c[i] = (real_t)2.0 * a[i] - b[i];
+        }
+    }
+
+    _Pragma("acc exit data copyout(c[0:n]) delete(a[0:n], b[0:n])")
+
+    for (int i = 0; i < n; ++i){
+        if (fabs(c[i] - ((real_t)2.0 * a[i] - b[i])) > PRECISION){
+            err += 1;
+        }
+    }
+
+    delete [] a;
+    delete [] b;
+    delete [] c;
+    return err;
+}
+#endif
+
+int main(){
+    int failcode = 0;
+    int failed;
+
+#ifndef T1
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test1();
+    }
+    if (failed != 0) failcode |= (1 << 0);
+#endif
+
+#ifndef T2
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test2();
+    }
+    if (failed != 0) failcode |= (1 << 1);
+#endif
+
+    return failcode;
+}

--- a/Tests/acc_pragma_operator.cpp
+++ b/Tests/acc_pragma_operator.cpp
@@ -5,9 +5,9 @@
 //   #pragma acc ... or the equivalent _Pragma("acc ...") operator form.
 //
 // Notes:
-// - These tests use only the _Pragma("acc ...") form.
-// - Structured (data/parallel/loop) and executable (enter/exit data)
-//   directives are exercised.
+// - T1: Uses _Pragma for data + parallel + loop and checks computation.
+// - T2: Uses _Pragma for enter data / exit data and checks computation.
+//
 
 
 #include "acc_testsuite.h"
@@ -107,7 +107,9 @@ int main(){
     for (int i = 0; i < NUM_TEST_CALLS; ++i){
         failed += test1();
     }
-    if (failed != 0) failcode |= (1 << 0);
+    if (failed != 0){
+        failcode |= (1 << 0);
+    }
 #endif
 
 #ifndef T2
@@ -115,7 +117,9 @@ int main(){
     for (int i = 0; i < NUM_TEST_CALLS; ++i){
         failed += test2();
     }
-    if (failed != 0) failcode |= (1 << 1);
+    if (failed != 0){
+        failcode |= (1 << 1);
+    }
 #endif
 
     return failcode;


### PR DESCRIPTION
### Feature
OpenACC 3.4 Section 2.1 clarifies that in C and C++, OpenACC directives may be written either as #pragma acc ... or equivalently using the standard C/C++ _Pragma("acc ...") operator form. This is primarily a front-end conformance requirement: compilers must correctly recognize and apply OpenACC directives expressed via _Pragma.

### What this PR adds
This PR introduces two new Validation & Verification test files:
   •acc_pragma_operator.c
   •acc_pragma_operator.cpp
Each file contains two tests that use _Pragma("acc ...") and validate correct runtime behavior by comparing device-computed results against expected host values.

### Test coverage
   •T1: Uses _Pragma for structured and loop-associated directives:
data(copyin/copy), parallel, and loop, verifying correct computation and implicit copy-back for the output array.
   •T2: Uses _Pragma for standalone executable data directives:
enter data(copyin/create), then parallel present(...) + loop, followed by exit data(copyout/delete) to validate explicit data lifetime management and correct copy-back.

### Compiler validation
Verified locally with:
   •GCC 15.2.0
   •NVIDIA NVHPC 25.5

### Results
   •PASS on GCC 15.2.0 (C and C++)
   •PASS on NVHPC 25.5 (C and C++)