### PR TITLE
Updating T2 in Serial_copyout.F90

### DIFF
--- a/Tests/serial_copyout.F90
+++ b/Tests/serial_copyout.F90
@@ -71,7 +71,7 @@
   CALL RANDOM_SEED(PUT=SEEDDIM)
 
   CALL RANDOM_NUMBER(a)
-  b = 2 * a
+  b = a
 
   IF (hasDevice(1) .eq. 1) THEN
     !$acc data copyin(a(1:LOOPCOUNT), b(1:LOOPCOUNT))


### PR DESCRIPTION
Change initialization of b from 2 * a to a in T2. Because, copyout action is not performed.

Thank you @SusanTan for catching this