### PR TITLE
Add async-argument and wait-argument grammar tests on compute constructs

### DIFF
--- a/Tests/acc_async_wait_argument_compute.F90
+++ b/Tests/acc_async_wait_argument_compute.F90
@@ -1,0 +1,427 @@
+! acc_async_wait_argument_compute.F90
+!
+! Feature under test (OpenACC 3.4, Sections 2.5 and 2.16, March 2026):
+! Compute constructs now use the async-argument and wait-argument
+! grammar consistently with the rest of the specification.
+!
+! Tests:
+! T1 – Basic async expression and wait.
+! T2 – wait(queues: ...) syntax.
+! T3 – Default async queue behavior.
+! T4 – wait(devnum: ...) syntax.
+! T5 – wait(devnum: ... : queues: ...) syntax.
+! T6 – async(acc_async_sync).
+! T7 – async(acc_async_noval).
+
+
+#ifndef T1
+!T1:async,wait,runtime,compute-constructs,baseline,V:3.4-
+      LOGICAL FUNCTION test1()
+        USE OPENACC
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: i, errors
+        INTEGER :: q, q0
+        REAL(8), DIMENSION(LOOPCOUNT) :: a, b, c
+
+        errors = 0
+
+        SEEDDIM(1) = 1
+#       ifdef SEED
+        SEEDDIM(1) = SEED
+#       endif
+        CALL RANDOM_SEED(PUT=SEEDDIM)
+        CALL RANDOM_NUMBER(a)
+        CALL RANDOM_NUMBER(b)
+        c = 0.0D0
+
+        q  = 4
+        q0 = q - q   ! nonnegative scalar integer expression (evaluates to 0)
+
+        !$acc data copyin(a(1:LOOPCOUNT), b(1:LOOPCOUNT)) copy(c(1:LOOPCOUNT))
+          !$acc parallel loop present(a(1:LOOPCOUNT), b(1:LOOPCOUNT), c(1:LOOPCOUNT)) async(q0)
+          DO i = 1, LOOPCOUNT
+            c(i) = a(i) + b(i)
+          END DO
+          !$acc end parallel loop
+
+          !$acc wait
+        !$acc end data
+
+        DO i = 1, LOOPCOUNT
+          IF (ABS(c(i) - (a(i) + b(i))) .GT. PRECISION) errors = errors + 1
+        END DO
+
+        test1 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+#ifndef T2
+!T2:wait-argument,syntax,compute-constructs,queues-modifier,V:3.4-
+      LOGICAL FUNCTION test2()
+        USE OPENACC
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: i, errors
+        REAL(8), DIMENSION(LOOPCOUNT) :: a, b, c, d, e
+
+        errors = 0
+
+        SEEDDIM(1) = 1
+#       ifdef SEED
+        SEEDDIM(1) = SEED
+#       endif
+        CALL RANDOM_SEED(PUT=SEEDDIM)
+        CALL RANDOM_NUMBER(a)
+        CALL RANDOM_NUMBER(b)
+        c = 0.0D0
+        d = 0.0D0
+        e = 0.0D0
+
+        !$acc enter data copyin(a(1:LOOPCOUNT), b(1:LOOPCOUNT)) create(c(1:LOOPCOUNT), d(1:LOOPCOUNT), e(1:LOOPCOUNT))
+
+        !$acc parallel loop present(a(1:LOOPCOUNT), c(1:LOOPCOUNT)) async(1)
+        DO i = 1, LOOPCOUNT
+          c(i) = a(i) * 2.0D0
+        END DO
+        !$acc end parallel loop
+
+        !$acc parallel loop present(b(1:LOOPCOUNT), d(1:LOOPCOUNT)) async(2)
+        DO i = 1, LOOPCOUNT
+          d(i) = b(i) * 3.0D0
+        END DO
+        !$acc end parallel loop
+
+        ! Spec-valid OpenACC 3.4 wait-argument form under test:
+        !$acc parallel loop present(c(1:LOOPCOUNT), d(1:LOOPCOUNT), e(1:LOOPCOUNT)) async(3) wait(queues: 1, 2)
+        DO i = 1, LOOPCOUNT
+          e(i) = c(i) + d(i)
+        END DO
+        !$acc end parallel loop
+
+        !$acc update self(e(1:LOOPCOUNT)) async(3)
+        DO WHILE (.NOT. acc_async_test(3))
+        END DO
+
+        DO i = 1, LOOPCOUNT
+          IF (ABS(e(i) - (a(i)*2.0D0 + b(i)*3.0D0)) .GT. PRECISION) errors = errors + 1
+        END DO
+
+        !$acc exit data delete(a(1:LOOPCOUNT), b(1:LOOPCOUNT), c(1:LOOPCOUNT), d(1:LOOPCOUNT), e(1:LOOPCOUNT))
+
+        test2 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+#ifndef T3
+!T3:async-argument,runtime-api,default-async,compute-constructs,V:3.4-
+      LOGICAL FUNCTION test3()
+        USE OPENACC
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: i, errors
+        INTEGER :: q
+        REAL(8), DIMENSION(LOOPCOUNT) :: a, b, c
+
+        errors = 0
+        q = 7
+
+        ! Spec intent: set and use the default async queue.
+        ! Some compilers may not provide this routine in the OPENACC module/runtime.
+        CALL acc_set_default_async(q)
+
+        SEEDDIM(1) = 1
+#       ifdef SEED
+        SEEDDIM(1) = SEED
+#       endif
+        CALL RANDOM_SEED(PUT=SEEDDIM)
+        CALL RANDOM_NUMBER(a)
+        CALL RANDOM_NUMBER(b)
+        c = 0.0D0
+
+        !$acc enter data copyin(a(1:LOOPCOUNT), b(1:LOOPCOUNT)) create(c(1:LOOPCOUNT))
+
+        ! "async" with no argument => use default async queue (spec behavior)
+        !$acc parallel loop present(a(1:LOOPCOUNT), b(1:LOOPCOUNT), c(1:LOOPCOUNT)) async
+        DO i = 1, LOOPCOUNT
+          c(i) = a(i) - b(i)
+        END DO
+        !$acc end parallel loop
+
+        IF (acc_get_default_async() .NE. q) errors = errors + 1
+
+        !$acc update self(c(1:LOOPCOUNT)) async(q)
+        DO WHILE (.NOT. acc_async_test(q))
+        END DO
+
+        DO i = 1, LOOPCOUNT
+          IF (ABS(c(i) - (a(i) - b(i))) .GT. PRECISION) errors = errors + 1
+        END DO
+
+        !$acc exit data delete(a(1:LOOPCOUNT), b(1:LOOPCOUNT), c(1:LOOPCOUNT))
+
+        test3 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+#ifndef T4
+!T4:wait-argument,syntax,compute-constructs,devnum-prefix,V:3.4-
+      LOGICAL FUNCTION test4()
+        USE OPENACC
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: i, errors
+        REAL(8), DIMENSION(LOOPCOUNT) :: a, b
+
+        errors = 0
+        a = 1.0D0
+        b = 0.0D0
+
+        !$acc data copy(a(1:LOOPCOUNT), b(1:LOOPCOUNT))
+          !$acc parallel loop async(1)
+          DO i = 1, LOOPCOUNT
+            b(i) = a(i) * 2.0D0
+          END DO
+          !$acc end parallel loop
+
+          ! Spec-valid OpenACC 3.4 wait-argument form under test:
+          !$acc parallel loop async(2) wait(devnum: 0 : 1)
+          DO i = 1, LOOPCOUNT
+            a(i) = b(i) + 1.0D0
+          END DO
+          !$acc end parallel loop
+
+          !$acc update self(a(1:LOOPCOUNT)) async(2)
+          DO WHILE (.NOT. acc_async_test(2))
+          END DO
+        !$acc end data
+
+        DO i = 1, LOOPCOUNT
+          IF (ABS(a(i) - 3.0D0) .GT. PRECISION) errors = errors + 1
+        END DO
+
+        test4 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+#ifndef T5
+!T5:wait-argument,syntax,compute-constructs,devnum-queues-prefix,V:3.4-
+      LOGICAL FUNCTION test5()
+        USE OPENACC
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: i, errors
+        REAL(8), DIMENSION(LOOPCOUNT) :: a, b, c
+
+        errors = 0
+
+        SEEDDIM(1) = 1
+#       ifdef SEED
+        SEEDDIM(1) = SEED
+#       endif
+        CALL RANDOM_SEED(PUT=SEEDDIM)
+        CALL RANDOM_NUMBER(a)
+        CALL RANDOM_NUMBER(b)
+        c = 0.0D0
+
+        !$acc data copyin(a(1:LOOPCOUNT), b(1:LOOPCOUNT)) copy(c(1:LOOPCOUNT))
+          !$acc parallel loop async(1)
+          DO i = 1, LOOPCOUNT
+            c(i) = a(i) + b(i)
+          END DO
+          !$acc end parallel loop
+
+          ! Spec-valid OpenACC 3.4 wait-argument combined form under test:
+          !$acc parallel loop async(2) wait(devnum: 0 : queues: 1)
+          DO i = 1, LOOPCOUNT
+            c(i) = c(i) * 2.0D0
+          END DO
+          !$acc end parallel loop
+
+          !$acc update self(c(1:LOOPCOUNT)) async(2)
+          DO WHILE (.NOT. acc_async_test(2))
+          END DO
+        !$acc end data
+
+        DO i = 1, LOOPCOUNT
+          IF (ABS(c(i) - 2.0D0*(a(i) + b(i))) .GT. PRECISION) errors = errors + 1
+        END DO
+
+        test5 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+#ifndef T6
+!T6:async-argument,special-value,compute-constructs,acc_async_sync,V:3.4-
+      LOGICAL FUNCTION test6()
+        USE OPENACC
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: i, errors
+        REAL(8), DIMENSION(LOOPCOUNT) :: a, b, c
+
+        errors = 0
+
+        SEEDDIM(1) = 1
+#       ifdef SEED
+        SEEDDIM(1) = SEED
+#       endif
+        CALL RANDOM_SEED(PUT=SEEDDIM)
+        CALL RANDOM_NUMBER(a)
+        CALL RANDOM_NUMBER(b)
+        c = 0.0D0
+
+        !$acc data copyin(a(1:LOOPCOUNT), b(1:LOOPCOUNT)) copy(c(1:LOOPCOUNT))
+          !$acc parallel loop async(acc_async_sync)
+          DO i = 1, LOOPCOUNT
+            c(i) = a(i) + b(i)
+          END DO
+          !$acc end parallel loop
+
+          !$acc wait
+        !$acc end data
+
+        DO i = 1, LOOPCOUNT
+          IF (ABS(c(i) - (a(i) + b(i))) .GT. PRECISION) errors = errors + 1
+        END DO
+
+        test6 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+#ifndef T7
+!T7:async-argument,special-value,compute-constructs,acc_async_noval,V:3.4-
+      LOGICAL FUNCTION test7()
+        USE OPENACC
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: i, errors
+        REAL(8), DIMENSION(LOOPCOUNT) :: a, b, c
+
+        errors = 0
+
+        SEEDDIM(1) = 1
+#       ifdef SEED
+        SEEDDIM(1) = SEED
+#       endif
+        CALL RANDOM_SEED(PUT=SEEDDIM)
+        CALL RANDOM_NUMBER(a)
+        CALL RANDOM_NUMBER(b)
+        c = 0.0D0
+
+        !$acc data copyin(a(1:LOOPCOUNT), b(1:LOOPCOUNT)) copy(c(1:LOOPCOUNT))
+          !$acc parallel loop async(acc_async_noval)
+          DO i = 1, LOOPCOUNT
+            c(i) = a(i) - b(i)
+          END DO
+          !$acc end parallel loop
+
+          !$acc wait
+        !$acc end data
+
+        DO i = 1, LOOPCOUNT
+          IF (ABS(c(i) - (a(i) - b(i))) .GT. PRECISION) errors = errors + 1
+        END DO
+
+        test7 = (errors .NE. 0)
+      END FUNCTION
+#endif
+
+
+      PROGRAM main
+        IMPLICIT NONE
+        INTEGER :: failcode, testrun
+        LOGICAL :: failed
+        INCLUDE "acc_testsuite.Fh"
+
+#ifndef T1
+        LOGICAL :: test1
+#endif
+#ifndef T2
+        LOGICAL :: test2
+#endif
+#ifndef T3
+        LOGICAL :: test3
+#endif
+#ifndef T4
+        LOGICAL :: test4
+#endif
+#ifndef T5
+        LOGICAL :: test5
+#endif
+#ifndef T6
+        LOGICAL :: test6
+#endif
+#ifndef T7
+        LOGICAL :: test7
+#endif
+
+        failcode = 0
+        failed = .FALSE.
+
+#ifndef T1
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .OR. test1()
+        END DO
+        IF (failed) THEN
+          failcode = failcode + 2 ** 0
+          failed = .FALSE.
+        END IF
+#endif
+#ifndef T2
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .OR. test2()
+        END DO
+        IF (failed) THEN
+          failcode = failcode + 2 ** 1
+          failed = .FALSE.
+        END IF
+#endif
+#ifndef T3
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .OR. test3()
+        END DO
+        IF (failed) THEN
+          failcode = failcode + 2 ** 2
+          failed = .FALSE.
+        END IF
+#endif
+#ifndef T4
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .OR. test4()
+        END DO
+        IF (failed) THEN
+          failcode = failcode + 2 ** 3
+          failed = .FALSE.
+        END IF
+#endif
+#ifndef T5
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .OR. test5()
+        END DO
+        IF (failed) THEN
+          failcode = failcode + 2 ** 4
+          failed = .FALSE.
+        END IF
+#endif
+#ifndef T6
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .OR. test6()
+        END DO
+        IF (failed) THEN
+          failcode = failcode + 2 ** 5
+          failed = .FALSE.
+        END IF
+#endif
+#ifndef T7
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .OR. test7()
+        END DO
+        IF (failed) THEN
+          failcode = failcode + 2 ** 6
+          failed = .FALSE.
+        END IF
+#endif
+
+        CALL EXIT(failcode)
+      END PROGRAM

--- a/Tests/acc_async_wait_argument_compute.c
+++ b/Tests/acc_async_wait_argument_compute.c
@@ -89,25 +89,37 @@ int test2() {
     #pragma acc enter data copyin(a[0:n], b[0:n]) create(c[0:n], d[0:n], e[0:n])
 
     #pragma acc parallel loop present(a[0:n], c[0:n]) async(1)
-    for (int i = 0; i < n; ++i) c[i] = a[i] * (real_t)2;
+    for (int i = 0; i < n; ++i){
+        c[i] = a[i] * (real_t)2;
+    }
 
     #pragma acc parallel loop present(b[0:n], d[0:n]) async(2)
-    for (int i = 0; i < n; ++i) d[i] = b[i] * (real_t)3;
+    for (int i = 0; i < n; ++i){
+        d[i] = b[i] * (real_t)3;
+    }
 
     /* Spec-valid wait-argument form under test */
     #pragma acc parallel loop present(c[0:n], d[0:n], e[0:n]) async(3) wait(queues: 1, 2)
-    for (int i = 0; i < n; ++i) e[i] = c[i] + d[i];
+    for (int i = 0; i < n; ++i){
+        e[i] = c[i] + d[i];
+    }
 
     #pragma acc update self(e[0:n]) async(3)
     while (!acc_async_test(3)) { }
 
     for (int i = 0; i < n; ++i) {
-        if (fabs(e[i] - (a[i]*(real_t)2 + b[i]*(real_t)3)) > PRECISION) err++;
+        if (fabs(e[i] - (a[i]*(real_t)2 + b[i]*(real_t)3)) > PRECISION){
+            err++;
+        }
     }
 
     #pragma acc exit data delete(a[0:n], b[0:n], c[0:n], d[0:n], e[0:n])
 
-    free(a); free(b); free(c); free(d); free(e);
+    free(a); 
+    free(b); 
+    free(c);
+    free(d);
+    free(e);
     return err;
 }
 #endif
@@ -123,7 +135,9 @@ int test3() {
     real_t *a = (real_t*)malloc(n * sizeof(real_t));
     real_t *b = (real_t*)malloc(n * sizeof(real_t));
     real_t *c = (real_t*)malloc(n * sizeof(real_t));
-    if (!a || !b || !c) return 1;
+    if (!a || !b || !c){
+        return 1;
+    }
 
     for (int i = 0; i < n; ++i) {
         a[i] = rand() / (real_t)(RAND_MAX / 10);
@@ -135,20 +149,28 @@ int test3() {
 
     /* async (no arg) => default async queue */
     #pragma acc parallel loop present(a[0:n], b[0:n], c[0:n]) async
-    for (int i = 0; i < n; ++i) c[i] = a[i] - b[i];
+    for (int i = 0; i < n; ++i){
+        c[i] = a[i] - b[i];
+    }
 
-    if (acc_get_default_async() != q) err++;
+    if (acc_get_default_async() != q){
+        err++;
+    }
 
     #pragma acc update self(c[0:n]) async(q)
     while (!acc_async_test(q)) { }
 
     for (int i = 0; i < n; ++i) {
-        if (fabs(c[i] - (a[i] - b[i])) > PRECISION) err++;
+        if (fabs(c[i] - (a[i] - b[i])) > PRECISION){
+            err++;
+        }
     }
 
     #pragma acc exit data delete(a[0:n], b[0:n], c[0:n])
 
-    free(a); free(b); free(c);
+    free(a); 
+    free(b); 
+    free(c);
     return err;
 }
 #endif
@@ -160,28 +182,39 @@ int test4() {
 
     real_t *a = (real_t*)malloc(n * sizeof(real_t));
     real_t *b = (real_t*)malloc(n * sizeof(real_t));
-    if (!a || !b) return 1;
+    if (!a || !b){
+        return 1;
+    }
 
-    for (int i = 0; i < n; ++i) { a[i] = (real_t)1; b[i] = (real_t)0; }
+    for (int i = 0; i < n; ++i){
+        a[i] = (real_t)1; b[i] = (real_t)0; 
+    }
 
     #pragma acc data copy(a[0:n], b[0:n])
     {
         #pragma acc parallel loop async(1)
-        for (int i = 0; i < n; ++i) b[i] = a[i] * (real_t)2;
+        for (int i = 0; i < n; ++i){
+            b[i] = a[i] * (real_t)2;
+        }
 
         /* wait(devnum: 0 : 1) => wait on queue 1 for device 0 */
         #pragma acc parallel loop async(2) wait(devnum: 0 : 1)
-        for (int i = 0; i < n; ++i) a[i] = b[i] + (real_t)1;
+        for (int i = 0; i < n; ++i){
+            a[i] = b[i] + (real_t)1;
+        }
 
         #pragma acc update self(a[0:n]) async(2)
         while (!acc_async_test(2)) { }
     }
 
     for (int i = 0; i < n; ++i) {
-        if (fabs(a[i] - (real_t)3) > PRECISION) err++;
+        if (fabs(a[i] - (real_t)3) > PRECISION){
+            err++;
+        }
     }
 
-    free(a); free(b);
+    free(a); 
+    free(b);
     return err;
 }
 #endif
@@ -194,7 +227,9 @@ int test5() {
     real_t *a = (real_t*)malloc(n * sizeof(real_t));
     real_t *b = (real_t*)malloc(n * sizeof(real_t));
     real_t *c = (real_t*)malloc(n * sizeof(real_t));
-    if (!a || !b || !c) return 1;
+    if (!a || !b || !c){
+        return 1;
+    }
 
     for (int i = 0; i < n; ++i) {
         a[i] = rand() / (real_t)(RAND_MAX / 10);
@@ -205,20 +240,28 @@ int test5() {
     #pragma acc data copyin(a[0:n], b[0:n]) copy(c[0:n])
     {
         #pragma acc parallel loop async(1)
-        for (int i = 0; i < n; ++i) c[i] = a[i] + b[i];
+        for (int i = 0; i < n; ++i){
+            c[i] = a[i] + b[i];
+        }
 
         #pragma acc parallel loop async(2) wait(devnum: 0 : queues: 1)
-        for (int i = 0; i < n; ++i) c[i] = c[i] * (real_t)2;
+        for (int i = 0; i < n; ++i){
+            c[i] = c[i] * (real_t)2;
+        }
 
         #pragma acc update self(c[0:n]) async(2)
         while (!acc_async_test(2)) { }
     }
 
     for (int i = 0; i < n; ++i) {
-        if (fabs(c[i] - (real_t)2*(a[i] + b[i])) > PRECISION) err++;
+        if (fabs(c[i] - (real_t)2*(a[i] + b[i])) > PRECISION){
+            err++;
+        }
     }
 
-    free(a); free(b); free(c);
+    free(a); 
+    free(b); 
+    free(c);
     return err;
 }
 #endif
@@ -231,7 +274,9 @@ int test6() {
     real_t *a = (real_t*)malloc(n * sizeof(real_t));
     real_t *b = (real_t*)malloc(n * sizeof(real_t));
     real_t *c = (real_t*)malloc(n * sizeof(real_t));
-    if (!a || !b || !c) return 1;
+    if (!a || !b || !c){
+        return 1;
+    }
 
     for (int i = 0; i < n; ++i) {
         a[i] = rand() / (real_t)(RAND_MAX / 10);
@@ -242,16 +287,22 @@ int test6() {
     #pragma acc data copyin(a[0:n], b[0:n]) copy(c[0:n])
     {
         #pragma acc parallel loop async(acc_async_sync)
-        for (int i = 0; i < n; ++i) c[i] = a[i] + b[i];
+        for (int i = 0; i < n; ++i){
+            c[i] = a[i] + b[i];
+        }
 
         #pragma acc wait
     }
 
     for (int i = 0; i < n; ++i) {
-        if (fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+        if (fabs(c[i] - (a[i] + b[i])) > PRECISION){
+            err++;
+        }
     }
 
-    free(a); free(b); free(c);
+    free(a); 
+    free(b); 
+    free(c);
     return err;
 }
 #endif
@@ -264,7 +315,9 @@ int test7() {
     real_t *a = (real_t*)malloc(n * sizeof(real_t));
     real_t *b = (real_t*)malloc(n * sizeof(real_t));
     real_t *c = (real_t*)malloc(n * sizeof(real_t));
-    if (!a || !b || !c) return 1;
+    if (!a || !b || !c){
+        return 1;
+    }
 
     for (int i = 0; i < n; ++i) {
         a[i] = rand() / (real_t)(RAND_MAX / 10);
@@ -275,16 +328,22 @@ int test7() {
     #pragma acc data copyin(a[0:n], b[0:n]) copy(c[0:n])
     {
         #pragma acc parallel loop async(acc_async_noval)
-        for (int i = 0; i < n; ++i) c[i] = a[i] - b[i];
+        for (int i = 0; i < n; ++i){
+            c[i] = a[i] - b[i];
+        }
 
         #pragma acc wait
     }
 
     for (int i = 0; i < n; ++i) {
-        if (fabs(c[i] - (a[i] - b[i])) > PRECISION) err++;
+        if (fabs(c[i] - (a[i] - b[i])) > PRECISION){
+            err++;
+        }
     }
 
-    free(a); free(b); free(c);
+    free(a); 
+    free(b); 
+    free(c);
     return err;
 }
 #endif
@@ -295,38 +354,66 @@ int main() {
 
 #ifndef T1
     failed = 0;
-    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test1();
-    if (failed) failcode |= (1 << 0);
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test1();
+    }
+    if (failed){
+        failcode |= (1 << 0);
+    }
 #endif
 #ifndef T2
     failed = 0;
-    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test2();
-    if (failed) failcode |= (1 << 1);
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test2();
+    }
+    if (failed){
+        failcode |= (1 << 1);
+    }
 #endif
 #ifndef T3
     failed = 0;
-    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test3();
-    if (failed) failcode |= (1 << 2);
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test3();
+    }
+    if (failed){
+        failcode |= (1 << 2);
+    }
 #endif
 #ifndef T4
     failed = 0;
-    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test4();
-    if (failed) failcode |= (1 << 3);
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test4();
+    }
+    if (failed){
+        failcode |= (1 << 3);
+    }
 #endif
 #ifndef T5
     failed = 0;
-    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test5();
-    if (failed) failcode |= (1 << 4);
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test5();
+    }
+    if (failed){
+        failcode |= (1 << 4);
+    }
 #endif
 #ifndef T6
     failed = 0;
-    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test6();
-    if (failed) failcode |= (1 << 5);
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test6();
+    }
+    if (failed){
+        failcode |= (1 << 5);
+    }
 #endif
 #ifndef T7
     failed = 0;
-    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test7();
-    if (failed) failcode |= (1 << 6);
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test7();
+    }
+    if (failed){
+        failcode |= (1 << 6);
+    }
 #endif
 
     return failcode;

--- a/Tests/acc_async_wait_argument_compute.c
+++ b/Tests/acc_async_wait_argument_compute.c
@@ -1,0 +1,333 @@
+// acc_async_wait_argument_compute.c
+//
+// Feature under test (OpenACC 3.4, Sections 2.5 and 2.16, March 2026):
+// Compute constructs were updated to use the async-argument and
+// wait-argument grammar consistently with the rest of the specification
+//
+// Tests:
+// T1 – Basic async usage: Runs a parallel loop using async(q0) where q0
+//      is an integer expression, followed by wait with no argument.
+// T2 – queues modifier: Uses wait(queues: 1,2) on a compute construct.
+// T3 – Default async queue: Uses async with no argument after setting
+//      the default queue with acc_set_default_async().
+// T4 – devnum modifier: Uses wait(devnum: 0 : 1).
+// T5 – devnum + queues: Uses wait(devnum: 0 : queues: 1).
+// T6 – Explicit acc_async_sync: Uses async(acc_async_sync).
+// T7 – Explicit acc_async_noval: Uses async(acc_async_noval).
+
+#include "acc_testsuite.h"
+#include <openacc.h>
+#include <math.h>
+#include <stdlib.h>
+
+#ifndef T1
+//T1:async,wait,runtime,compute-constructs,baseline,V:3.4-
+int test1() {
+    int err = 0;
+    srand(SEED);
+
+    real_t *a = (real_t*)malloc(n * sizeof(real_t));
+    real_t *b = (real_t*)malloc(n * sizeof(real_t));
+    real_t *c = (real_t*)malloc(n * sizeof(real_t));
+    if (!a || !b || !c){
+        return 1;
+    }
+
+    for (int i = 0; i < n; ++i) {
+        a[i] = rand() / (real_t)(RAND_MAX / 10);
+        b[i] = rand() / (real_t)(RAND_MAX / 10);
+        c[i] = 0;
+    }
+
+    int q = 4;
+    int q0 = q - q; /* int-expr evaluating to 0 => nonnegative scalar integer expression */
+
+    #pragma acc data copyin(a[0:n], b[0:n]) copy(c[0:n])
+    {
+        #pragma acc parallel loop present(a[0:n], b[0:n], c[0:n]) async(q0)
+        for (int i = 0; i < n; ++i) {
+            c[i] = a[i] + b[i];
+        }
+
+        /* wait with no argument => wait-all activity queues (spec-valid) */
+        #pragma acc wait
+    }
+
+    for (int i = 0; i < n; ++i) {
+        if (fabs(c[i] - (a[i] + b[i])) > PRECISION){
+            err++;
+        }
+    }
+
+    free(a); 
+    free(b);
+    free(c);
+    return err;
+}
+#endif
+
+#ifndef T2
+int test2() {
+    int err = 0;
+    srand(SEED);
+
+    real_t *a = (real_t*)malloc(n * sizeof(real_t));
+    real_t *b = (real_t*)malloc(n * sizeof(real_t));
+    real_t *c = (real_t*)malloc(n * sizeof(real_t));
+    real_t *d = (real_t*)malloc(n * sizeof(real_t));
+    real_t *e = (real_t*)malloc(n * sizeof(real_t));
+    if (!a || !b || !c || !d || !e){
+        return 1;
+    }
+
+    for (int i = 0; i < n; ++i) {
+        a[i] = rand() / (real_t)(RAND_MAX / 10);
+        b[i] = rand() / (real_t)(RAND_MAX / 10);
+        c[i] = d[i] = e[i] = 0;
+    }
+
+    #pragma acc enter data copyin(a[0:n], b[0:n]) create(c[0:n], d[0:n], e[0:n])
+
+    #pragma acc parallel loop present(a[0:n], c[0:n]) async(1)
+    for (int i = 0; i < n; ++i) c[i] = a[i] * (real_t)2;
+
+    #pragma acc parallel loop present(b[0:n], d[0:n]) async(2)
+    for (int i = 0; i < n; ++i) d[i] = b[i] * (real_t)3;
+
+    /* Spec-valid wait-argument form under test */
+    #pragma acc parallel loop present(c[0:n], d[0:n], e[0:n]) async(3) wait(queues: 1, 2)
+    for (int i = 0; i < n; ++i) e[i] = c[i] + d[i];
+
+    #pragma acc update self(e[0:n]) async(3)
+    while (!acc_async_test(3)) { }
+
+    for (int i = 0; i < n; ++i) {
+        if (fabs(e[i] - (a[i]*(real_t)2 + b[i]*(real_t)3)) > PRECISION) err++;
+    }
+
+    #pragma acc exit data delete(a[0:n], b[0:n], c[0:n], d[0:n], e[0:n])
+
+    free(a); free(b); free(c); free(d); free(e);
+    return err;
+}
+#endif
+
+#ifndef T3
+int test3() {
+    int err = 0;
+    srand(SEED);
+
+    const int q = 7;
+    acc_set_default_async(q);
+
+    real_t *a = (real_t*)malloc(n * sizeof(real_t));
+    real_t *b = (real_t*)malloc(n * sizeof(real_t));
+    real_t *c = (real_t*)malloc(n * sizeof(real_t));
+    if (!a || !b || !c) return 1;
+
+    for (int i = 0; i < n; ++i) {
+        a[i] = rand() / (real_t)(RAND_MAX / 10);
+        b[i] = rand() / (real_t)(RAND_MAX / 10);
+        c[i] = 0;
+    }
+
+    #pragma acc enter data copyin(a[0:n], b[0:n]) create(c[0:n])
+
+    /* async (no arg) => default async queue */
+    #pragma acc parallel loop present(a[0:n], b[0:n], c[0:n]) async
+    for (int i = 0; i < n; ++i) c[i] = a[i] - b[i];
+
+    if (acc_get_default_async() != q) err++;
+
+    #pragma acc update self(c[0:n]) async(q)
+    while (!acc_async_test(q)) { }
+
+    for (int i = 0; i < n; ++i) {
+        if (fabs(c[i] - (a[i] - b[i])) > PRECISION) err++;
+    }
+
+    #pragma acc exit data delete(a[0:n], b[0:n], c[0:n])
+
+    free(a); free(b); free(c);
+    return err;
+}
+#endif
+
+#ifndef T4
+int test4() {
+    int err = 0;
+    srand(SEED);
+
+    real_t *a = (real_t*)malloc(n * sizeof(real_t));
+    real_t *b = (real_t*)malloc(n * sizeof(real_t));
+    if (!a || !b) return 1;
+
+    for (int i = 0; i < n; ++i) { a[i] = (real_t)1; b[i] = (real_t)0; }
+
+    #pragma acc data copy(a[0:n], b[0:n])
+    {
+        #pragma acc parallel loop async(1)
+        for (int i = 0; i < n; ++i) b[i] = a[i] * (real_t)2;
+
+        /* wait(devnum: 0 : 1) => wait on queue 1 for device 0 */
+        #pragma acc parallel loop async(2) wait(devnum: 0 : 1)
+        for (int i = 0; i < n; ++i) a[i] = b[i] + (real_t)1;
+
+        #pragma acc update self(a[0:n]) async(2)
+        while (!acc_async_test(2)) { }
+    }
+
+    for (int i = 0; i < n; ++i) {
+        if (fabs(a[i] - (real_t)3) > PRECISION) err++;
+    }
+
+    free(a); free(b);
+    return err;
+}
+#endif
+
+#ifndef T5
+int test5() {
+    int err = 0;
+    srand(SEED);
+
+    real_t *a = (real_t*)malloc(n * sizeof(real_t));
+    real_t *b = (real_t*)malloc(n * sizeof(real_t));
+    real_t *c = (real_t*)malloc(n * sizeof(real_t));
+    if (!a || !b || !c) return 1;
+
+    for (int i = 0; i < n; ++i) {
+        a[i] = rand() / (real_t)(RAND_MAX / 10);
+        b[i] = rand() / (real_t)(RAND_MAX / 10);
+        c[i] = 0;
+    }
+
+    #pragma acc data copyin(a[0:n], b[0:n]) copy(c[0:n])
+    {
+        #pragma acc parallel loop async(1)
+        for (int i = 0; i < n; ++i) c[i] = a[i] + b[i];
+
+        #pragma acc parallel loop async(2) wait(devnum: 0 : queues: 1)
+        for (int i = 0; i < n; ++i) c[i] = c[i] * (real_t)2;
+
+        #pragma acc update self(c[0:n]) async(2)
+        while (!acc_async_test(2)) { }
+    }
+
+    for (int i = 0; i < n; ++i) {
+        if (fabs(c[i] - (real_t)2*(a[i] + b[i])) > PRECISION) err++;
+    }
+
+    free(a); free(b); free(c);
+    return err;
+}
+#endif
+
+#ifndef T6
+int test6() {
+    int err = 0;
+    srand(SEED);
+
+    real_t *a = (real_t*)malloc(n * sizeof(real_t));
+    real_t *b = (real_t*)malloc(n * sizeof(real_t));
+    real_t *c = (real_t*)malloc(n * sizeof(real_t));
+    if (!a || !b || !c) return 1;
+
+    for (int i = 0; i < n; ++i) {
+        a[i] = rand() / (real_t)(RAND_MAX / 10);
+        b[i] = rand() / (real_t)(RAND_MAX / 10);
+        c[i] = 0;
+    }
+
+    #pragma acc data copyin(a[0:n], b[0:n]) copy(c[0:n])
+    {
+        #pragma acc parallel loop async(acc_async_sync)
+        for (int i = 0; i < n; ++i) c[i] = a[i] + b[i];
+
+        #pragma acc wait
+    }
+
+    for (int i = 0; i < n; ++i) {
+        if (fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+    }
+
+    free(a); free(b); free(c);
+    return err;
+}
+#endif
+
+#ifndef T7
+int test7() {
+    int err = 0;
+    srand(SEED);
+
+    real_t *a = (real_t*)malloc(n * sizeof(real_t));
+    real_t *b = (real_t*)malloc(n * sizeof(real_t));
+    real_t *c = (real_t*)malloc(n * sizeof(real_t));
+    if (!a || !b || !c) return 1;
+
+    for (int i = 0; i < n; ++i) {
+        a[i] = rand() / (real_t)(RAND_MAX / 10);
+        b[i] = rand() / (real_t)(RAND_MAX / 10);
+        c[i] = 0;
+    }
+
+    #pragma acc data copyin(a[0:n], b[0:n]) copy(c[0:n])
+    {
+        #pragma acc parallel loop async(acc_async_noval)
+        for (int i = 0; i < n; ++i) c[i] = a[i] - b[i];
+
+        #pragma acc wait
+    }
+
+    for (int i = 0; i < n; ++i) {
+        if (fabs(c[i] - (a[i] - b[i])) > PRECISION) err++;
+    }
+
+    free(a); free(b); free(c);
+    return err;
+}
+#endif
+
+int main() {
+    int failcode = 0;
+    int failed;
+
+#ifndef T1
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test1();
+    if (failed) failcode |= (1 << 0);
+#endif
+#ifndef T2
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test2();
+    if (failed) failcode |= (1 << 1);
+#endif
+#ifndef T3
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test3();
+    if (failed) failcode |= (1 << 2);
+#endif
+#ifndef T4
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test4();
+    if (failed) failcode |= (1 << 3);
+#endif
+#ifndef T5
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test5();
+    if (failed) failcode |= (1 << 4);
+#endif
+#ifndef T6
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test6();
+    if (failed) failcode |= (1 << 5);
+#endif
+#ifndef T7
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test7();
+    if (failed) failcode |= (1 << 6);
+#endif
+
+    return failcode;
+}

--- a/Tests/acc_async_wait_argument_compute.cpp
+++ b/Tests/acc_async_wait_argument_compute.cpp
@@ -27,7 +27,9 @@ int test1() {
     real_t *a = (real_t*)std::malloc(n * sizeof(real_t));
     real_t *b = (real_t*)std::malloc(n * sizeof(real_t));
     real_t *c = (real_t*)std::malloc(n * sizeof(real_t));
-    if (!a || !b || !c) return 1;
+    if (!a || !b || !c){
+        return 1;
+    }
 
     for (int i = 0; i < n; ++i) {
         a[i] = std::rand() / (real_t)(RAND_MAX / 10);
@@ -41,16 +43,22 @@ int test1() {
     #pragma acc data copyin(a[0:n], b[0:n]) copy(c[0:n])
     {
         #pragma acc parallel loop present(a[0:n], b[0:n], c[0:n]) async(q0)
-        for (int i = 0; i < n; ++i) c[i] = a[i] + b[i];
+        for (int i = 0; i < n; ++i){
+            c[i] = a[i] + b[i];
+        }
 
         #pragma acc wait
     }
 
     for (int i = 0; i < n; ++i) {
-        if (std::fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+        if (std::fabs(c[i] - (a[i] + b[i])) > PRECISION){
+            err++;
+        }
     }
 
-    std::free(a); std::free(b); std::free(c);
+    std::free(a); 
+    std::free(b);
+    std::free(c);
     return err;
 }
 #endif
@@ -65,7 +73,9 @@ int test2() {
     real_t *c = (real_t*)std::malloc(n * sizeof(real_t));
     real_t *d = (real_t*)std::malloc(n * sizeof(real_t));
     real_t *e = (real_t*)std::malloc(n * sizeof(real_t));
-    if (!a || !b || !c || !d || !e) return 1;
+    if (!a || !b || !c || !d || !e){
+        return 1;
+    }
 
     for (int i = 0; i < n; ++i) {
         a[i] = std::rand() / (real_t)(RAND_MAX / 10);
@@ -76,24 +86,36 @@ int test2() {
     #pragma acc enter data copyin(a[0:n], b[0:n]) create(c[0:n], d[0:n], e[0:n])
 
     #pragma acc parallel loop present(a[0:n], c[0:n]) async(1)
-    for (int i = 0; i < n; ++i) c[i] = a[i] * (real_t)2;
+    for (int i = 0; i < n; ++i){
+        c[i] = a[i] * (real_t)2;
+    }
 
     #pragma acc parallel loop present(b[0:n], d[0:n]) async(2)
-    for (int i = 0; i < n; ++i) d[i] = b[i] * (real_t)3;
+    for (int i = 0; i < n; ++i){
+        d[i] = b[i] * (real_t)3;
+    }
 
     #pragma acc parallel loop present(c[0:n], d[0:n], e[0:n]) async(3) wait(queues: 1, 2)
-    for (int i = 0; i < n; ++i) e[i] = c[i] + d[i];
+    for (int i = 0; i < n; ++i){
+        e[i] = c[i] + d[i];
+    }
 
     #pragma acc update self(e[0:n]) async(3)
     while (!acc_async_test(3)) { }
 
     for (int i = 0; i < n; ++i) {
-        if (std::fabs(e[i] - (a[i]*(real_t)2 + b[i]*(real_t)3)) > PRECISION) err++;
+        if (std::fabs(e[i] - (a[i]*(real_t)2 + b[i]*(real_t)3)) > PRECISION){
+            err++;
+        }
     }
 
     #pragma acc exit data delete(a[0:n], b[0:n], c[0:n], d[0:n], e[0:n])
 
-    std::free(a); std::free(b); std::free(c); std::free(d); std::free(e);
+    std::free(a); 
+    std::free(b); 
+    std::free(c); 
+    std::free(d); 
+    std::free(e);
     return err;
 }
 #endif
@@ -109,7 +131,9 @@ int test3() {
     real_t *a = (real_t*)std::malloc(n * sizeof(real_t));
     real_t *b = (real_t*)std::malloc(n * sizeof(real_t));
     real_t *c = (real_t*)std::malloc(n * sizeof(real_t));
-    if (!a || !b || !c) return 1;
+    if (!a || !b || !c){
+        return 1;
+    }
 
     for (int i = 0; i < n; ++i) {
         a[i] = std::rand() / (real_t)(RAND_MAX / 10);
@@ -120,20 +144,28 @@ int test3() {
     #pragma acc enter data copyin(a[0:n], b[0:n]) create(c[0:n])
 
     #pragma acc parallel loop present(a[0:n], b[0:n], c[0:n]) async
-    for (int i = 0; i < n; ++i) c[i] = a[i] - b[i];
+    for (int i = 0; i < n; ++i){
+        c[i] = a[i] - b[i];
+    }
 
-    if (acc_get_default_async() != q) err++;
+    if (acc_get_default_async() != q){
+        err++;
+    }
 
     #pragma acc update self(c[0:n]) async(q)
     while (!acc_async_test(q)) { }
 
     for (int i = 0; i < n; ++i) {
-        if (std::fabs(c[i] - (a[i] - b[i])) > PRECISION) err++;
+        if (std::fabs(c[i] - (a[i] - b[i])) > PRECISION){
+            err++;
+        }
     }
 
     #pragma acc exit data delete(a[0:n], b[0:n], c[0:n])
 
-    std::free(a); std::free(b); std::free(c);
+    std::free(a);
+    std::free(b); 
+    std::free(c);
     return err;
 }
 #endif
@@ -145,27 +177,39 @@ int test4() {
 
     real_t *a = (real_t*)std::malloc(n * sizeof(real_t));
     real_t *b = (real_t*)std::malloc(n * sizeof(real_t));
-    if (!a || !b) return 1;
+    if (!a || !b){
+        return 1;
+    }
 
-    for (int i = 0; i < n; ++i) { a[i] = (real_t)1; b[i] = (real_t)0; }
+    for (int i = 0; i < n; ++i){
+        a[i] = (real_t)1; 
+        b[i] = (real_t)0; 
+    }
 
     #pragma acc data copy(a[0:n], b[0:n])
     {
         #pragma acc parallel loop async(1)
-        for (int i = 0; i < n; ++i) b[i] = a[i] * (real_t)2;
+        for (int i = 0; i < n; ++i){
+            b[i] = a[i] * (real_t)2;
+        }
 
         #pragma acc parallel loop async(2) wait(devnum: 0 : 1)
-        for (int i = 0; i < n; ++i) a[i] = b[i] + (real_t)1;
+        for (int i = 0; i < n; ++i){
+            a[i] = b[i] + (real_t)1;
+        }
 
         #pragma acc update self(a[0:n]) async(2)
         while (!acc_async_test(2)) { }
     }
 
     for (int i = 0; i < n; ++i) {
-        if (std::fabs(a[i] - (real_t)3) > PRECISION) err++;
+        if (std::fabs(a[i] - (real_t)3) > PRECISION){
+            err++;
+        }
     }
 
-    std::free(a); std::free(b);
+    std::free(a); 
+    std::free(b);
     return err;
 }
 #endif
@@ -178,7 +222,9 @@ int test5() {
     real_t *a = (real_t*)std::malloc(n * sizeof(real_t));
     real_t *b = (real_t*)std::malloc(n * sizeof(real_t));
     real_t *c = (real_t*)std::malloc(n * sizeof(real_t));
-    if (!a || !b || !c) return 1;
+    if (!a || !b || !c){
+        return 1;
+    }
 
     for (int i = 0; i < n; ++i) {
         a[i] = std::rand() / (real_t)(RAND_MAX / 10);
@@ -189,20 +235,28 @@ int test5() {
     #pragma acc data copyin(a[0:n], b[0:n]) copy(c[0:n])
     {
         #pragma acc parallel loop async(1)
-        for (int i = 0; i < n; ++i) c[i] = a[i] + b[i];
+        for (int i = 0; i < n; ++i){
+            c[i] = a[i] + b[i];
+        }
 
         #pragma acc parallel loop async(2) wait(devnum: 0 : queues: 1)
-        for (int i = 0; i < n; ++i) c[i] = c[i] * (real_t)2;
+        for (int i = 0; i < n; ++i){
+            c[i] = c[i] * (real_t)2;
+        }
 
         #pragma acc update self(c[0:n]) async(2)
         while (!acc_async_test(2)) { }
     }
 
     for (int i = 0; i < n; ++i) {
-        if (std::fabs(c[i] - (real_t)2*(a[i] + b[i])) > PRECISION) err++;
+        if (std::fabs(c[i] - (real_t)2*(a[i] + b[i])) > PRECISION){
+            err++;
+        }
     }
 
-    std::free(a); std::free(b); std::free(c);
+    std::free(a); 
+    std::free(b); 
+    std::free(c);
     return err;
 }
 #endif
@@ -215,7 +269,9 @@ int test6() {
     real_t *a = (real_t*)std::malloc(n * sizeof(real_t));
     real_t *b = (real_t*)std::malloc(n * sizeof(real_t));
     real_t *c = (real_t*)std::malloc(n * sizeof(real_t));
-    if (!a || !b || !c) return 1;
+    if (!a || !b || !c){
+        return 1;
+    }
 
     for (int i = 0; i < n; ++i) {
         a[i] = std::rand() / (real_t)(RAND_MAX / 10);
@@ -226,16 +282,22 @@ int test6() {
     #pragma acc data copyin(a[0:n], b[0:n]) copy(c[0:n])
     {
         #pragma acc parallel loop async(acc_async_sync)
-        for (int i = 0; i < n; ++i) c[i] = a[i] + b[i];
+        for (int i = 0; i < n; ++i){
+            c[i] = a[i] + b[i];
+        }
 
         #pragma acc wait
     }
 
     for (int i = 0; i < n; ++i) {
-        if (std::fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+        if (std::fabs(c[i] - (a[i] + b[i])) > PRECISION){
+            err++;
+        }
     }
 
-    std::free(a); std::free(b); std::free(c);
+    std::free(a); 
+    std::free(b); 
+    std::free(c);
     return err;
 }
 #endif
@@ -248,7 +310,9 @@ int test7() {
     real_t *a = (real_t*)std::malloc(n * sizeof(real_t));
     real_t *b = (real_t*)std::malloc(n * sizeof(real_t));
     real_t *c = (real_t*)std::malloc(n * sizeof(real_t));
-    if (!a || !b || !c) return 1;
+    if (!a || !b || !c){
+        return 1;
+    }
 
     for (int i = 0; i < n; ++i) {
         a[i] = std::rand() / (real_t)(RAND_MAX / 10);
@@ -259,16 +323,22 @@ int test7() {
     #pragma acc data copyin(a[0:n], b[0:n]) copy(c[0:n])
     {
         #pragma acc parallel loop async(acc_async_noval)
-        for (int i = 0; i < n; ++i) c[i] = a[i] - b[i];
+        for (int i = 0; i < n; ++i){
+            c[i] = a[i] - b[i];
+        }
 
         #pragma acc wait
     }
 
     for (int i = 0; i < n; ++i) {
-        if (std::fabs(c[i] - (a[i] - b[i])) > PRECISION) err++;
+        if (std::fabs(c[i] - (a[i] - b[i])) > PRECISION){
+            err++;
+        }
     }
 
-    std::free(a); std::free(b); std::free(c);
+    std::free(a); 
+    std::free(b); 
+    std::free(c);
     return err;
 }
 #endif
@@ -279,38 +349,66 @@ int main() {
 
 #ifndef T1
     failed = 0;
-    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test1();
-    if (failed) failcode |= (1 << 0);
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test1();
+    }
+    if (failed){
+        failcode |= (1 << 0);
+    }
 #endif
 #ifndef T2
     failed = 0;
-    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test2();
-    if (failed) failcode |= (1 << 1);
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test2();
+    }
+    if (failed){
+        failcode |= (1 << 1);
+    }
 #endif
 #ifndef T3
     failed = 0;
-    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test3();
-    if (failed) failcode |= (1 << 2);
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test3();
+    }
+    if (failed){
+        failcode |= (1 << 2);
+    }
 #endif
 #ifndef T4
     failed = 0;
-    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test4();
-    if (failed) failcode |= (1 << 3);
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test4();
+    }
+    if (failed){
+        failcode |= (1 << 3);
+    }
 #endif
 #ifndef T5
     failed = 0;
-    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test5();
-    if (failed) failcode |= (1 << 4);
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test5();
+    }
+    if (failed){
+        failcode |= (1 << 4);
+    }
 #endif
 #ifndef T6
     failed = 0;
-    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test6();
-    if (failed) failcode |= (1 << 5);
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test6();
+    }
+    if (failed){
+        failcode |= (1 << 5);
+    }
 #endif
 #ifndef T7
     failed = 0;
-    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test7();
-    if (failed) failcode |= (1 << 6);
+    for (int i = 0; i < NUM_TEST_CALLS; ++i){
+        failed += test7();
+    }
+    if (failed){
+        failcode |= (1 << 6);
+    }
 #endif
 
     return failcode;

--- a/Tests/acc_async_wait_argument_compute.cpp
+++ b/Tests/acc_async_wait_argument_compute.cpp
@@ -1,0 +1,317 @@
+// acc_async_wait_argument_compute.cpp
+//
+// Feature under test (OpenACC 3.4, Sections 2.5 and 2.16, March 2026):
+// Compute constructs now use the async-argument and wait-argument
+// grammar consistently with the rest of the specification.
+//
+// Tests:
+// T1 – Basic async expression and wait.
+// T2 – wait(queues: ...) syntax.
+// T3 – Default async queue behavior using runtime API.
+// T4 – wait(devnum: ...) syntax.
+// T5 – wait(devnum: ... : queues: ...) syntax.
+// T6 – async(acc_async_sync).
+// T7 – async(acc_async_noval).
+
+#include "acc_testsuite.h"
+#include <openacc.h>
+#include <cmath>
+#include <cstdlib>
+
+#ifndef T1
+//T1:async,wait,runtime,compute-constructs,baseline,V:3.4-
+int test1() {
+    int err = 0;
+    std::srand(SEED);
+
+    real_t *a = (real_t*)std::malloc(n * sizeof(real_t));
+    real_t *b = (real_t*)std::malloc(n * sizeof(real_t));
+    real_t *c = (real_t*)std::malloc(n * sizeof(real_t));
+    if (!a || !b || !c) return 1;
+
+    for (int i = 0; i < n; ++i) {
+        a[i] = std::rand() / (real_t)(RAND_MAX / 10);
+        b[i] = std::rand() / (real_t)(RAND_MAX / 10);
+        c[i] = 0;
+    }
+
+    int q = 4;
+    int q0 = q - q;
+
+    #pragma acc data copyin(a[0:n], b[0:n]) copy(c[0:n])
+    {
+        #pragma acc parallel loop present(a[0:n], b[0:n], c[0:n]) async(q0)
+        for (int i = 0; i < n; ++i) c[i] = a[i] + b[i];
+
+        #pragma acc wait
+    }
+
+    for (int i = 0; i < n; ++i) {
+        if (std::fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+    }
+
+    std::free(a); std::free(b); std::free(c);
+    return err;
+}
+#endif
+
+#ifndef T2
+int test2() {
+    int err = 0;
+    std::srand(SEED);
+
+    real_t *a = (real_t*)std::malloc(n * sizeof(real_t));
+    real_t *b = (real_t*)std::malloc(n * sizeof(real_t));
+    real_t *c = (real_t*)std::malloc(n * sizeof(real_t));
+    real_t *d = (real_t*)std::malloc(n * sizeof(real_t));
+    real_t *e = (real_t*)std::malloc(n * sizeof(real_t));
+    if (!a || !b || !c || !d || !e) return 1;
+
+    for (int i = 0; i < n; ++i) {
+        a[i] = std::rand() / (real_t)(RAND_MAX / 10);
+        b[i] = std::rand() / (real_t)(RAND_MAX / 10);
+        c[i] = d[i] = e[i] = 0;
+    }
+
+    #pragma acc enter data copyin(a[0:n], b[0:n]) create(c[0:n], d[0:n], e[0:n])
+
+    #pragma acc parallel loop present(a[0:n], c[0:n]) async(1)
+    for (int i = 0; i < n; ++i) c[i] = a[i] * (real_t)2;
+
+    #pragma acc parallel loop present(b[0:n], d[0:n]) async(2)
+    for (int i = 0; i < n; ++i) d[i] = b[i] * (real_t)3;
+
+    #pragma acc parallel loop present(c[0:n], d[0:n], e[0:n]) async(3) wait(queues: 1, 2)
+    for (int i = 0; i < n; ++i) e[i] = c[i] + d[i];
+
+    #pragma acc update self(e[0:n]) async(3)
+    while (!acc_async_test(3)) { }
+
+    for (int i = 0; i < n; ++i) {
+        if (std::fabs(e[i] - (a[i]*(real_t)2 + b[i]*(real_t)3)) > PRECISION) err++;
+    }
+
+    #pragma acc exit data delete(a[0:n], b[0:n], c[0:n], d[0:n], e[0:n])
+
+    std::free(a); std::free(b); std::free(c); std::free(d); std::free(e);
+    return err;
+}
+#endif
+
+#ifndef T3
+int test3() {
+    int err = 0;
+    std::srand(SEED);
+
+    const int q = 7;
+    acc_set_default_async(q);
+
+    real_t *a = (real_t*)std::malloc(n * sizeof(real_t));
+    real_t *b = (real_t*)std::malloc(n * sizeof(real_t));
+    real_t *c = (real_t*)std::malloc(n * sizeof(real_t));
+    if (!a || !b || !c) return 1;
+
+    for (int i = 0; i < n; ++i) {
+        a[i] = std::rand() / (real_t)(RAND_MAX / 10);
+        b[i] = std::rand() / (real_t)(RAND_MAX / 10);
+        c[i] = 0;
+    }
+
+    #pragma acc enter data copyin(a[0:n], b[0:n]) create(c[0:n])
+
+    #pragma acc parallel loop present(a[0:n], b[0:n], c[0:n]) async
+    for (int i = 0; i < n; ++i) c[i] = a[i] - b[i];
+
+    if (acc_get_default_async() != q) err++;
+
+    #pragma acc update self(c[0:n]) async(q)
+    while (!acc_async_test(q)) { }
+
+    for (int i = 0; i < n; ++i) {
+        if (std::fabs(c[i] - (a[i] - b[i])) > PRECISION) err++;
+    }
+
+    #pragma acc exit data delete(a[0:n], b[0:n], c[0:n])
+
+    std::free(a); std::free(b); std::free(c);
+    return err;
+}
+#endif
+
+#ifndef T4
+int test4() {
+    int err = 0;
+    std::srand(SEED);
+
+    real_t *a = (real_t*)std::malloc(n * sizeof(real_t));
+    real_t *b = (real_t*)std::malloc(n * sizeof(real_t));
+    if (!a || !b) return 1;
+
+    for (int i = 0; i < n; ++i) { a[i] = (real_t)1; b[i] = (real_t)0; }
+
+    #pragma acc data copy(a[0:n], b[0:n])
+    {
+        #pragma acc parallel loop async(1)
+        for (int i = 0; i < n; ++i) b[i] = a[i] * (real_t)2;
+
+        #pragma acc parallel loop async(2) wait(devnum: 0 : 1)
+        for (int i = 0; i < n; ++i) a[i] = b[i] + (real_t)1;
+
+        #pragma acc update self(a[0:n]) async(2)
+        while (!acc_async_test(2)) { }
+    }
+
+    for (int i = 0; i < n; ++i) {
+        if (std::fabs(a[i] - (real_t)3) > PRECISION) err++;
+    }
+
+    std::free(a); std::free(b);
+    return err;
+}
+#endif
+
+#ifndef T5
+int test5() {
+    int err = 0;
+    std::srand(SEED);
+
+    real_t *a = (real_t*)std::malloc(n * sizeof(real_t));
+    real_t *b = (real_t*)std::malloc(n * sizeof(real_t));
+    real_t *c = (real_t*)std::malloc(n * sizeof(real_t));
+    if (!a || !b || !c) return 1;
+
+    for (int i = 0; i < n; ++i) {
+        a[i] = std::rand() / (real_t)(RAND_MAX / 10);
+        b[i] = std::rand() / (real_t)(RAND_MAX / 10);
+        c[i] = 0;
+    }
+
+    #pragma acc data copyin(a[0:n], b[0:n]) copy(c[0:n])
+    {
+        #pragma acc parallel loop async(1)
+        for (int i = 0; i < n; ++i) c[i] = a[i] + b[i];
+
+        #pragma acc parallel loop async(2) wait(devnum: 0 : queues: 1)
+        for (int i = 0; i < n; ++i) c[i] = c[i] * (real_t)2;
+
+        #pragma acc update self(c[0:n]) async(2)
+        while (!acc_async_test(2)) { }
+    }
+
+    for (int i = 0; i < n; ++i) {
+        if (std::fabs(c[i] - (real_t)2*(a[i] + b[i])) > PRECISION) err++;
+    }
+
+    std::free(a); std::free(b); std::free(c);
+    return err;
+}
+#endif
+
+#ifndef T6
+int test6() {
+    int err = 0;
+    std::srand(SEED);
+
+    real_t *a = (real_t*)std::malloc(n * sizeof(real_t));
+    real_t *b = (real_t*)std::malloc(n * sizeof(real_t));
+    real_t *c = (real_t*)std::malloc(n * sizeof(real_t));
+    if (!a || !b || !c) return 1;
+
+    for (int i = 0; i < n; ++i) {
+        a[i] = std::rand() / (real_t)(RAND_MAX / 10);
+        b[i] = std::rand() / (real_t)(RAND_MAX / 10);
+        c[i] = 0;
+    }
+
+    #pragma acc data copyin(a[0:n], b[0:n]) copy(c[0:n])
+    {
+        #pragma acc parallel loop async(acc_async_sync)
+        for (int i = 0; i < n; ++i) c[i] = a[i] + b[i];
+
+        #pragma acc wait
+    }
+
+    for (int i = 0; i < n; ++i) {
+        if (std::fabs(c[i] - (a[i] + b[i])) > PRECISION) err++;
+    }
+
+    std::free(a); std::free(b); std::free(c);
+    return err;
+}
+#endif
+
+#ifndef T7
+int test7() {
+    int err = 0;
+    std::srand(SEED);
+
+    real_t *a = (real_t*)std::malloc(n * sizeof(real_t));
+    real_t *b = (real_t*)std::malloc(n * sizeof(real_t));
+    real_t *c = (real_t*)std::malloc(n * sizeof(real_t));
+    if (!a || !b || !c) return 1;
+
+    for (int i = 0; i < n; ++i) {
+        a[i] = std::rand() / (real_t)(RAND_MAX / 10);
+        b[i] = std::rand() / (real_t)(RAND_MAX / 10);
+        c[i] = 0;
+    }
+
+    #pragma acc data copyin(a[0:n], b[0:n]) copy(c[0:n])
+    {
+        #pragma acc parallel loop async(acc_async_noval)
+        for (int i = 0; i < n; ++i) c[i] = a[i] - b[i];
+
+        #pragma acc wait
+    }
+
+    for (int i = 0; i < n; ++i) {
+        if (std::fabs(c[i] - (a[i] - b[i])) > PRECISION) err++;
+    }
+
+    std::free(a); std::free(b); std::free(c);
+    return err;
+}
+#endif
+
+int main() {
+    int failcode = 0;
+    int failed;
+
+#ifndef T1
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test1();
+    if (failed) failcode |= (1 << 0);
+#endif
+#ifndef T2
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test2();
+    if (failed) failcode |= (1 << 1);
+#endif
+#ifndef T3
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test3();
+    if (failed) failcode |= (1 << 2);
+#endif
+#ifndef T4
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test4();
+    if (failed) failcode |= (1 << 3);
+#endif
+#ifndef T5
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test5();
+    if (failed) failcode |= (1 << 4);
+#endif
+#ifndef T6
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test6();
+    if (failed) failcode |= (1 << 5);
+#endif
+#ifndef T7
+    failed = 0;
+    for (int i = 0; i < NUM_TEST_CALLS; ++i) failed += test7();
+    if (failed) failcode |= (1 << 6);
+#endif
+
+    return failcode;
+}


### PR DESCRIPTION
### Feature
This pull request adds new validation tests for the OpenACC 3.4 specification change that corrected the grammar of compute constructs to use async-argument and wait-argument consistently with the rest of the specification (see Sections 2.5 and 2.16 of the OpenACC 3.4 spec).

The update clarifies that compute constructs such as parallel, serial, and kernels should accept the same async and wait clause grammar used elsewhere in the specification, including:
• async(<async-argument>)
• async with no argument
• async with no argument
• wait(queues: ...)
• wait(devnum: ... : ...)
• wait(devnum: ... : queues: ...)

### Tests Added
T1 – Baseline async expression
Runs a parallel loop using async(q0) where q0 is a nonnegative integer expression (q - q).
Then uses wait with no argument to synchronize execution.
Tests:
•async-argument acceptance on compute constructs
•wait with no argument (wait on all queues)

T2 – queues modifier
Launches two asynchronous kernels on queues 1 and 2, then runs a third compute construct with:
`wait(queues: 1, 2)`
Tests:
• queues: modifier in the wait-argument grammar

T3 – Default async queue
Uses the runtime API:
```
acc_set_default_async()
acc_get_default_async()
```
A compute construct is launched using async with no argument to verify that it executes on the default queue.
Tests:
• implicit async argument behavior
• interaction between compute constructs and the default async queue.

T4 – devnum modifier
Uses:
`wait(devnum: 0 : 1)`
Tests:
• devnum: mpdifier in the wait-argument grammar.

T5 – devnum + queues
Uses the full wait grammar:
`wait(devnum: 0 : queues: 1)`
Tests:
• full wait-argument grammar path.

T6 – Explicit acc_async_sync
Uses:
`async(acc_async_sync)`
Tests explicit use of the special async value rather than relying on implicit behavior.

T7 – Explicit acc_async_noval
Uses:
`async(acc_async_noval)`
Tests explicit use of the special async value rather than relying on the shorthand async with no argument.

### Compiler Testing Results
### GCC 15.2.0:
*C:
**T2 - wait(queues:...):
```
error: ‘queues’ undeclared (first use in this function)
error: expected ')' before ':' token
```
The compiler interprets queues as an undeclared identifier rather than the 'queues:' modifier defined in the OpenACC 3.4 wait-argument grammar.

**T3 - Default Async Runtime API
```
error: implicit declaration of function ‘acc_set_default_async’
error: implicit declaration of function ‘acc_get_default_async’
```
- These functions are part of the OpenACC runtime API used to set and retrieve the default asynchronous queue.
- The errors suggest that these runtime functions are not visible through the default OpenACC headers in this configuration

**T4 - wait(devnum:...)
Same error as T2 - the compiler interprets devnum as a variable rather than recognize the 'devnum:' modifier in the OpenACC 3.4 grammar

**T5 - wait(devnum:... : queues: ...)
Reports similar errors:
```
error: ‘devnum’ undeclared
error: expected ')' before ':' token
```

*C++
**T2 - wait(queues: ...)
`error: ‘queues’ was not declared in this scope`

**T3 - Default Async Runtime API
```
error: ‘acc_set_default_async’ was not declared in this scope
error: ‘acc_get_default_async’ was not declared in this scope
```

**T4 - wait(devnum: ...)
`error: ‘devnum’ was not declared in this scope`

**T5 - wait(devnum: ... : queues: ...)
`error: ‘devnum’ was not declared in this scope`

These errors indicate that the parser is not recognizing 'queues:' and 'devnum:' as OpenACC clause modifiers

*Fortran
**T2 - wait(queues: ...)
`Error: Syntax error in OpenACC expression list`
This indicates that the compiler does not recognize the queues: modifier inside the wait clause.

After rejecting the wait(...) syntax, the compiler also reports:
```
Unexpected !$ACC END PARALLEL LOOP statement
Expecting !$ACC END DATA
```
These errors appear to be parse errors caused by the compiler failing to recognize the opening directive once the wait-argument syntax is rejected

**T3 - Default Async Runtime API
`Function 'acc_get_default_async' has no IMPLICIT type`
This indicates that the runtime API function is not recognized through the OpenACC modules or headers in this environment

### NVIDIA 26.1
*C/C++
**T2 - wait(queues: ...)
```
error: identifier "queues" is undefined
error: expected a ")"
```

**T4 - wait(devnum: ...)
```
error: identifier "devnum" is undefined
error: expected a ")"
```

**t5 - wait(devnum:... : queues:...)
```
error: identifier "devnum" is undefined
error: expected a ")"
```
These errors indicate that the NVHPC parser does not currently recognize the queues: or devnum: modifiers in the wait clause

*Fortran
NVHPC reports:
```
acc_set_default_async is use associated with openacc_la and cannot be redeclared
acc_get_default_async is use associated with openacc_la and cannot be redeclared
```
These errors occur because NVHPC already provides interfaces for these runtime API functions through the OpenACC module

**T2/T4/T5 - wait grammar
NVHPC also reports errors such as:
`Syntax error at or near :`
for directives using:
```
wait(queues: ...)
wait(devnum: ...)
wait(devnum: ... : queues: ...)
```

### Cray 18.0.0
*Fortran
**T2 - wait(queues:...)
Cray reports:
```
explicit type must be specified for data object "QUEUES"
")" was expected but found ":"
```

**T4 - wait(devnum:...)
```
explicit type must be specified for data object "DEVNUM"
")" was expected but found ":"
```

**T5 - wait(devnum:... : queues: ...)
Similar errors occur, again indicating that the compiler is interpreting queues and devnum as identifiers rather than directive modifiers.

### Summary
These tests validate the OpenACC 3.4 grammar correction for compute constructs using async-argument and wait-argument

Testing across GCC, NVHPC, and Cray compilers shows that several implementations currently reject syntax that is valid according to the OpenACC 3.4 Specification, particularly the extended wait clause grammar

These tests help identify the discrepancies between the specification and current compiler implementations and provide useful conformance tests for future compiler updates.
