### PR TITLE
Add validation test for single if clause on data and host constructs

### DIFF
--- a/Tests/copy_host_if.F90
+++ b/Tests/copy_host_if.F90
@@ -1,0 +1,58 @@
+! copy_host_if.F90
+!
+!Feature under test (OpenACC 3.4, Sections 2.6.5, 2.6.6, and 2.8. March 2026):
+! The specification clarifies that the data,
+! and host_data constructs may contain at most one if clause.
+! These tests verify correct behavior when a single valid if clause
+! is used on these constructs.
+!
+! Tests:
+! T1 - combined constructs with single if clauses:
+!      Uses both data and host_data constructs within the same region,
+!      each containing a single if clause, verifying that multiple
+!      constructs can independently use valid if clauses.
+
+#ifndef T1
+!T1:syntax,data,host-data,if-clause,construct-independent,V:3.4-
+      LOGICAL FUNCTION test1()
+        USE OPENACC
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: x
+        INTEGER :: errors = 0
+        INTEGER :: host
+        REAL(8), DIMENSION(LOOPCOUNT) :: a, b
+
+        host = 0
+        SEEDDIM(1) = 1
+#       ifdef SEED
+        SEEDDIM(1) = SEED
+#       endif
+        CALL RANDOM_SEED(PUT=SEEDDIM)
+        CALL RANDOM_NUMBER(a)
+        b = 0.0
+
+        !$acc data copy(a(1:LOOPCOUNT), b(1:LOOPCOUNT)) if(.TRUE.)
+          !$acc parallel loop present(a(1:LOOPCOUNT), b(1:LOOPCOUNT))
+          DO x = 1, LOOPCOUNT
+            b(x) = a(x) * 2.0
+          END DO
+          !$acc end parallel loop
+
+          !$acc host_data use_device(b) if(host .ne. 0)
+          !$acc end host_data
+        !$acc end data
+
+        DO x = 1, LOOPCOUNT
+          IF (abs(b(x) - (a(x) * 2.0)) .gt. PRECISION) THEN
+            errors = errors + 1
+          END IF
+        END DO
+
+        IF (errors .eq. 0) THEN
+          test1 = .FALSE.
+        ELSE
+          test1 = .TRUE.
+        END IF
+      END FUNCTION
+#endif

--- a/Tests/copy_host_if.c
+++ b/Tests/copy_host_if.c
@@ -1,0 +1,75 @@
+// copy_host_if.c
+//
+//Feature under test (OpenACC 3.4, Sections 2.6.5, 2.6.6, and 2.8. March 2026):
+// The specification clarifies that the data,
+// and host_data constructs may contain at most one if clause.
+// These tests verify correct behavior when a single valid if clause
+// is used on these constructs.
+//
+// Tests:
+// T1 - combined constructs with single if clauses:
+//      Uses both data and host_data constructs within the same region,
+//      each containing a single if clause, verifying that multiple
+//      constructs can independently use valid if clauses.
+
+
+#include "acc_testsuite.h"
+#include <openacc.h>
+
+#ifndef T1
+//T1:syntax,data,host-data,if-clause,construct-independent,V:3.4-
+int test1(){
+    int err = 0;
+    srand(SEED);
+
+    real_t *a = (real_t *)malloc(n * sizeof(real_t));
+    real_t *b = (real_t *)malloc(n * sizeof(real_t));
+    int host = 0;
+
+    for (int x = 0; x < n; ++x){
+        a[x] = rand() / (real_t)(RAND_MAX / 10);
+        b[x] = 0.0;
+    }
+
+    #pragma acc data copy(a[0:n], b[0:n]) if(1)
+    {
+        #pragma acc parallel loop present(a[0:n], b[0:n])
+        for (int x = 0; x < n; ++x){
+            b[x] = a[x] * 2.0;
+        }
+
+        #pragma acc host_data use_device(b) if(host)
+        {
+            ;
+        }
+    }
+
+    for (int x = 0; x < n; ++x){
+        if (fabs(b[x] - (a[x] * 2.0)) > PRECISION){
+            err += 1;
+        }
+    }
+
+    free(a);
+    free(b);
+
+    return err;
+}
+#endif
+
+int main(){
+    int failcode = 0;
+    int failed;
+
+#ifndef T1
+    failed = 0;
+    for (int x = 0; x < NUM_TEST_CALLS; ++x){
+        failed += test1();
+    }
+    if (failed != 0){
+        failcode += (1 << 0);
+    }
+#endif
+
+    return failcode;
+}

--- a/Tests/copy_host_if.cpp
+++ b/Tests/copy_host_if.cpp
@@ -1,0 +1,74 @@
+// copy_host_if.cpp
+//
+//Feature under test (OpenACC 3.4, Sections 2.6.5, 2.6.6, and 2.8. March 2026):
+// The specification clarifies that the data,
+// and host_data constructs may contain at most one if clause.
+// These tests verify correct behavior when a single valid if clause
+// is used on these constructs.
+//
+// Tests:
+// T1 - combined constructs with single if clauses:
+//      Uses both data and host_data constructs within the same region,
+//      each containing a single if clause, verifying that multiple
+//      constructs can independently use valid if clauses.
+
+#include "acc_testsuite.h"
+#include <openacc.h>
+
+#ifndef T1
+//T1:syntax,data,host-data,if-clause,construct-independent,V:3.4-
+int test1(){
+    int err = 0;
+    srand(SEED);
+
+    real_t *a = new real_t[n];
+    real_t *b = new real_t[n];
+    int host = 0;
+
+    for (int x = 0; x < n; ++x){
+        a[x] = rand() / (real_t)(RAND_MAX / 10);
+        b[x] = 0.0;
+    }
+
+    #pragma acc data copy(a[0:n], b[0:n]) if(1)
+    {
+        #pragma acc parallel loop present(a[0:n], b[0:n])
+        for (int x = 0; x < n; ++x){
+            b[x] = a[x] * 2.0;
+        }
+
+        #pragma acc host_data use_device(b) if(host)
+        {
+            ;
+        }
+    }
+
+    for (int x = 0; x < n; ++x){
+        if (fabs(b[x] - (a[x] * 2.0)) > PRECISION){
+            err += 1;
+        }
+    }
+
+    delete[] a;
+    delete[] b;
+
+    return err;
+}
+#endif
+
+int main(){
+    int failcode = 0;
+    int failed;
+
+#ifndef T1
+    failed = 0;
+    for (int x = 0; x < NUM_TEST_CALLS; ++x){
+        failed += test1();
+    }
+    if (failed != 0){
+        failcode += (1 << 0);
+    }
+#endif
+
+    return failcode;
+}

--- a/Tests/copy_if.F90
+++ b/Tests/copy_if.F90
@@ -1,0 +1,56 @@
+! copy_if.F90
+!
+!Feature under test (OpenACC 3.4, Sections 2.6.5, 2.6.6, and 2.8. March 2026):
+! The specification clarifies that the data,
+! and host_data constructs may contain at most one if clause.
+! These tests verify correct behavior when a single valid if clause
+! is used on these constructs.
+!
+! Tests:
+! T1 – data construct with single if clause:
+!      Uses a data region with copy and a single if(dev)
+!      clause controlling device execution.
+!
+
+
+#ifndef T1
+!T1:syntax,data,if-clause,construct-independent,V:3.4-
+      LOGICAL FUNCTION test1()
+        USE OPENACC
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: x
+        INTEGER :: errors = 0
+        INTEGER :: dev
+        REAL(8), DIMENSION(LOOPCOUNT) :: a, b
+
+        dev = 1
+        SEEDDIM(1) = 1
+#       ifdef SEED
+        SEEDDIM(1) = SEED
+#       endif
+        CALL RANDOM_SEED(PUT=SEEDDIM)
+        CALL RANDOM_NUMBER(a)
+        b = 0.0
+
+        !$acc data copy(a(1:LOOPCOUNT), b(1:LOOPCOUNT)) if(dev .ne. 0)
+          !$acc parallel loop present(a(1:LOOPCOUNT), b(1:LOOPCOUNT))
+          DO x = 1, LOOPCOUNT
+            b(x) = a(x) * 2.0
+          END DO
+          !$acc end parallel loop
+        !$acc end data
+
+        DO x = 1, LOOPCOUNT
+          IF (abs(b(x) - (a(x) * 2.0)) .gt. PRECISION) THEN
+            errors = errors + 1
+          END IF
+        END DO
+
+        IF (errors .eq. 0) THEN
+          test1 = .FALSE.
+        ELSE
+          test1 = .TRUE.
+        END IF
+      END FUNCTION
+#endif

--- a/Tests/copy_if.c
+++ b/Tests/copy_if.c
@@ -1,0 +1,69 @@
+// copy_if.c
+//
+//Feature under test (OpenACC 3.4, Sections 2.6.5, 2.6.6, and 2.8. March 2026):
+// The specification clarifies that the data,
+// and host_data constructs may contain at most one if clause.
+// These tests verify correct behavior when a single valid if clause
+// is used on these constructs.
+//
+// Tests:
+// T1 – data construct with single if clause:
+//      Uses a data region with copy and a single if(dev)
+//      clause controlling device execution.
+//
+
+#include "acc_testsuite.h"
+#include <openacc.h>
+
+#ifndef T1
+//T1:syntax,data,if-clause,construct-independent,V:3.4-
+int test1(){
+    int err = 0;
+    srand(SEED);
+
+    real_t *a = (real_t *)malloc(n * sizeof(real_t));
+    real_t *b = (real_t *)malloc(n * sizeof(real_t));
+    int dev = 1;
+
+    for (int x = 0; x < n; ++x){
+        a[x] = rand() / (real_t)(RAND_MAX / 10);
+        b[x] = 0.0;
+    }
+
+    #pragma acc data copy(a[0:n], b[0:n]) if(dev)
+    {
+        #pragma acc parallel loop present(a[0:n], b[0:n])
+        for (int x = 0; x < n; ++x){
+            b[x] = a[x] * 2.0;
+        }
+    }
+
+    for (int x = 0; x < n; ++x){
+        if (fabs(b[x] - (a[x] * 2.0)) > PRECISION){
+            err += 1;
+        }
+    }
+
+    free(a);
+    free(b);
+
+    return err;
+}
+#endif
+
+int main(){
+    int failcode = 0;
+    int failed;
+
+#ifndef T1
+    failed = 0;
+    for (int x = 0; x < NUM_TEST_CALLS; ++x){
+        failed += test1();
+    }
+    if (failed != 0){
+        failcode += (1 << 0);
+    }
+#endif
+
+    return failcode;
+}

--- a/Tests/copy_if.cpp
+++ b/Tests/copy_if.cpp
@@ -1,0 +1,70 @@
+// copy_if.cpp
+//
+//Feature under test (OpenACC 3.4, Sections 2.6.5, 2.6.6, and 2.8. March 2026):
+// The specification clarifies that the data,
+// and host_data constructs may contain at most one if clause.
+// These tests verify correct behavior when a single valid if clause
+// is used on these constructs.
+//
+// Tests:
+// T1 – data construct with single if clause:
+//      Uses a data region with copy and a single if(dev)
+//      clause controlling device execution.
+//
+
+
+#include "acc_testsuite.h"
+#include <openacc.h>
+
+#ifndef T1
+//T1:syntax,data,if-clause,construct-independent,V:3.4-
+int test1(){
+    int err = 0;
+    srand(SEED);
+
+    real_t *a = new real_t[n];
+    real_t *b = new real_t[n];
+    int dev = 1;
+
+    for (int x = 0; x < n; ++x){
+        a[x] = rand() / (real_t)(RAND_MAX / 10);
+        b[x] = 0.0;
+    }
+
+    #pragma acc data copy(a[0:n], b[0:n]) if(dev)
+    {
+        #pragma acc parallel loop present(a[0:n], b[0:n])
+        for (int x = 0; x < n; ++x){
+            b[x] = a[x] * 2.0;
+        }
+    }
+
+    for (int x = 0; x < n; ++x){
+        if (fabs(b[x] - (a[x] * 2.0)) > PRECISION){
+            err += 1;
+        }
+    }
+
+    delete[] a;
+    delete[] b;
+
+    return err;
+}
+#endif
+
+int main(){
+    int failcode = 0;
+    int failed;
+
+#ifndef T1
+    failed = 0;
+    for (int x = 0; x < NUM_TEST_CALLS; ++x){
+        failed += test1();
+    }
+    if (failed != 0){
+        failcode += (1 << 0);
+    }
+#endif
+
+    return failcode;
+}

--- a/Tests/host_if.F90
+++ b/Tests/host_if.F90
@@ -1,0 +1,77 @@
+! host_if.F90
+!
+! Feature under test (OpenACC 3.4, Sections 2.6.5, 2.6.6, and 2.8. March 2026):
+! The specification clarifies that the data, enter data, exit data,
+! and host_data constructs may contain at most one if clause.
+! These tests verify correct behavior when a single valid if clause
+! is used on these constructs.
+!
+! Tests:
+! T1 - host_data construct with single if clause:
+!      Uses host_data use_device(...) with if(dev) to confirm
+!      that device pointer access functions correctly.
+!
+#ifndef T1
+!T1:syntax,host-data,if-clause,construct-independent,V:3.4-
+      LOGICAL FUNCTION test1()
+        USE OPENACC
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: x
+        INTEGER :: errors = 0
+        INTEGER :: dev
+        REAL(8), DIMENSION(LOOPCOUNT), TARGET :: a
+        REAL(8), POINTER :: seen_ptr(:)
+
+        dev = 1
+        NULLIFY(seen_ptr)
+
+        SEEDDIM(1) = 1
+#       ifdef SEED
+        SEEDDIM(1) = SEED
+#       endif
+        CALL RANDOM_SEED(PUT=SEEDDIM)
+        CALL RANDOM_NUMBER(a)
+
+        !$acc data copyin(a(1:LOOPCOUNT))
+          !$acc host_data use_device(a) if(dev .ne. 0)
+            seen_ptr => a
+          !$acc end host_data
+        !$acc end data
+
+        IF (.not. ASSOCIATED(seen_ptr)) THEN
+          errors = errors + 1
+        END IF
+
+        IF (errors .eq. 0) THEN
+          test1 = .FALSE.
+        ELSE
+          test1 = .TRUE.
+        END IF
+      END FUNCTION
+#endif
+
+      PROGRAM main
+        IMPLICIT NONE
+        INTEGER :: failcode, testrun
+        LOGICAL :: failed
+        INCLUDE "acc_testsuite.Fh"
+#ifndef T1
+        LOGICAL :: test1
+#endif
+
+        failcode = 0
+        failed = .FALSE.
+
+#ifndef T1
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .or. test1()
+        END DO
+        IF (failed) THEN
+          failcode = failcode + 2 ** 0
+          failed = .FALSE.
+        END IF
+#endif
+
+        CALL EXIT(failcode)
+      END PROGRAM

--- a/Tests/host_if.c
+++ b/Tests/host_if.c
@@ -1,0 +1,61 @@
+// host_if.c
+//
+// Feature under test (OpenACC 3.4, Sections 2.6.5, 2.6.6, and 2.8. March 2026):
+// The specification clarifies that the data, enter data, exit data,
+// and host_data constructs may contain at most one if clause.
+// These tests verify correct behavior when a single valid if clause
+// is used on these constructs.
+//
+// Tests:
+// T1 - host_data construct with single if clause:
+//      Uses host_data use_device(...) with if(dev) to ensure device
+//      pointer access works correctly when an if clause is present.
+
+#include "acc_testsuite.h"
+#include <openacc.h>
+
+#ifndef T1
+int test1(){
+    int err = 0;
+    srand(SEED);
+
+    real_t *a = (real_t *)malloc(n * sizeof(real_t));
+    real_t *seen_ptr = NULL;
+    int dev = 1;
+
+    for (int x = 0; x < n; ++x){
+        a[x] = rand() / (real_t)(RAND_MAX / 10);
+    }
+
+    #pragma acc data copyin(a[0:n])
+    {
+        #pragma acc host_data use_device(a) if(dev)
+        {
+            seen_ptr = a;
+        }
+    }
+
+    if (seen_ptr == NULL){
+        err += 1;
+    }
+
+    free(a);
+
+    return err;
+}
+#endif
+
+int main(){
+    int failcode = 0;
+    int failed;
+#ifndef T1
+    failed = 0;
+    for (int x = 0; x < NUM_TEST_CALLS; ++x){
+        failed = failed + test1();
+    }
+    if (failed != 0){
+        failcode = failcode + (1 << 0);
+    }
+#endif
+    return failcode;
+}

--- a/Tests/host_if.cpp
+++ b/Tests/host_if.cpp
@@ -1,0 +1,61 @@
+// host_if.cpp
+//
+// Feature under test (OpenACC 3.4, Sections 2.6.5, 2.6.6, and 2.8. March 2026):
+// The specification clarifies that the data, enter data, exit data,
+// and host_data constructs may contain at most one if clause.
+// These tests verify correct behavior when a single valid if clause
+// is used on these constructs.
+//
+// Tests:
+// T1 - host_data construct with single if clause:
+//      Uses host_data use_device(...) with if(dev) to confirm
+//      that device pointer access functions correctly.
+//
+#include "acc_testsuite.h"
+#include <openacc.h>
+
+#ifndef T1
+int test1(){
+    int err = 0;
+    srand(SEED);
+
+    real_t *a = new real_t[n];
+    real_t *seen_ptr = NULL;
+    int dev = 1;
+
+    for (int x = 0; x < n; ++x){
+        a[x] = rand() / (real_t)(RAND_MAX / 10);
+    }
+
+    #pragma acc data copyin(a[0:n])
+    {
+        #pragma acc host_data use_device(a) if(dev)
+        {
+            seen_ptr = a;
+        }
+    }
+
+    if (seen_ptr == NULL){
+        err += 1;
+    }
+
+    delete[] a;
+
+    return err;
+}
+#endif
+
+int main(){
+    int failcode = 0;
+    int failed;
+#ifndef T1
+    failed = 0;
+    for (int x = 0; x < NUM_TEST_CALLS; ++x){
+        failed = failed + test1();
+    }
+    if (failed != 0){
+        failcode = failcode + (1 << 0);
+    }
+#endif
+    return failcode;
+}


### PR DESCRIPTION
### Feature Description
These files add validation tests for a clarification introduced in the OpenACC 3.4 specification affecting the use of the if clause on several data-related constructs.
Sections 2.6.5, 2.6.6 and 2.8 of the specification clarify and normalize that the following constructs may contain at most one if clause:
• data
• enter data
• exit data
• host_data
Earlier versions of the specification allowed the usage of if clauses on these constructs, but the restriction on the number of if clauses was not stated consistently. OpenACC 3.4 explicitly defines that only a single if clause may appear on these directives. Previous tests already exercise the enter and exit data portions, so we will ignore them in these tests.

### Tests Added
copy_if.c
copy_if.cpp
copy_if.F90
host_if.c
host_if.cpp
host_if.F90
copy_host_if.c
copy_host_if.cpp
copy_host_if.F90

### Test Coverage
The tests verify correct behavior when a single valid if clause is used on the constructs affected by the specification clarification.

copy_if T1:  Executes a data region using if(dev) and verifies correct data movement and computation.
Construct: data

host_if T1: Uses host_data use_device(a) if(dev) to verify that the construct accepts a single if clause and correctly exposes the device pointer.
Construct: host_data

copy_host_if T1:  Uses both constructs in the same region, each with a single if clause, verifying that constructs may independently include a valid if clause.
Construct: data + host_data

These tests are positive validation tests, confirming correct behavior for legal single-if clause usage as defined by the OpenACC 3.4 specification

### Compiler Testing
NVHPC 26.1 – PASS
GCC 15.2.0 – PASS
CRAY 18.0.0 – PASS

### Summary
This pr adds validation tests ensuring correct support for single if clause usage on data-related constructs as clarified in the OpenACC 3.4. The tests confirm that compilers correctly accept and execute directives containing a single if clause across the affected constructs and languages.
