### PR TITLE
Capture modifier test for copy, copyout, and create clauses

### DIFF
--- a/Tests/capture.F90
+++ b/Tests/capture.F90
@@ -1,3 +1,23 @@
+! capture.c
+!
+! Feature under test (OpenACC 3.4, Sections 2.7.4, 2.7.9, and 2.7.10, April 2026):
+! The capture modifier was added to data clauses to specify that a variable
+! requires a discrete device-accessible copy, even when the implementation
+! might otherwise use shared memory between the host and device.
+!
+! Tests:
+! T1 – copy(capture:...): Verifies that a captured copy is created at the
+!      start of a data region. The host modifies the variable after entry,
+!      and the device computation must use the original captured values.
+! T2 – copyout(capture:...): Verifies that a captured device copy is used
+!      during execution and that results are correctly copied back to the
+!      host at region exit. Host-side modifications after capture must not
+!      affect device computation.
+! T3 – create(capture:...): Verifies that a captured device-only copy is
+!      created and used across compute regions. The host version of the
+!      variable is modified after capture, and the device must use its own
+!      independent copy while the host value remains unchanged.
+
 #ifndef T1
 !T1:data,structured-data,construct-independent,capture-modifier,V:3.4
       LOGICAL FUNCTION test1()
@@ -8,7 +28,7 @@
         INTEGER :: errors = 0
         REAL(8), DIMENSION(LOOPCOUNT) :: x
 
-        x = 0
+        x = 2
 
         !$acc data copy(capture:x(1:LOOPCOUNT))
           x = 1
@@ -20,7 +40,7 @@
         !$acc end data
 
         DO i = 1, LOOPCOUNT
-          IF (abs(x(i) - 1) .gt. PRECISION) THEN
+          IF (abs(x(i) - 3.0D0) .gt. PRECISION) THEN
             errors = errors + 1
           END IF
         END DO
@@ -46,14 +66,23 @@
         a = -1
 
         !$acc data copyout(capture:a(1:LOOPCOUNT))
-          !$acc parallel loop copyout(a(1:LOOPCOUNT))
+          !$acc parallel loop present(a(1:LOOPCOUNT))
           DO i = 1, LOOPCOUNT
-            a(i) = i
+            a(i) = 0
+          END DO
+
+          DO i = 1, LOOPCOUNT
+            a(i) = 5
+          END DO
+
+          !$acc parallel loop present(a(1:LOOPCOUNT))
+          DO i = 1, LOOPCOUNT
+            a(i) = a(i) + 1
           END DO
         !$acc end data
 
         DO i = 1, LOOPCOUNT
-          IF (abs(a(i) - real(i,8)) .gt. PRECISION) THEN
+          IF (abs(a(i) - 1.0D0) .gt. PRECISION) THEN
             errors = errors + 1
           END IF
         END DO
@@ -83,12 +112,11 @@
         CALL RANDOM_SEED(PUT=SEEDDIM)
         CALL RANDOM_NUMBER(a)
         a_ref = a
-        b = -1
+        b = 0
 
         !$acc data copy(a(1:LOOPCOUNT)) create(capture:b(1:LOOPCOUNT))
-          !$acc parallel loop present(a(1:LOOPCOUNT), b(1:LOOPCOUNT))
           DO i = 1, LOOPCOUNT
-            b(i) = 1
+            b(i) = 5
           END DO
 
           !$acc parallel loop present(a(1:LOOPCOUNT), b(1:LOOPCOUNT))
@@ -98,10 +126,10 @@
         !$acc end data
 
         DO i = 1, LOOPCOUNT
-          IF (abs(a(i) - (a_ref(i) + 1)) .gt. PRECISION) THEN
+          IF (abs(a(i) - a_ref(i)) .gt. PRECISION) THEN
             errors = errors + 1
           END IF
-          IF (abs(b(i) - (-1.0D0)) .gt. PRECISION) THEN
+          IF (abs(b(i) - 5.0D0) .gt. PRECISION) THEN
             errors = errors + 1
           END IF
         END DO

--- a/Tests/capture.F90
+++ b/Tests/capture.F90
@@ -1,0 +1,166 @@
+#ifndef T1
+!T1:data,structured-data,construct-independent,capture-modifier,V:3.4
+      LOGICAL FUNCTION test1()
+        USE OPENACC
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: i
+        INTEGER :: errors = 0
+        REAL(8), DIMENSION(LOOPCOUNT) :: x
+
+        x = 0
+
+        !$acc data copy(capture:x(1:LOOPCOUNT))
+          x = 1
+
+          !$acc parallel loop copy(x(1:LOOPCOUNT))
+          DO i = 1, LOOPCOUNT
+            x(i) = x(i) + 1
+          END DO
+        !$acc end data
+
+        DO i = 1, LOOPCOUNT
+          IF (abs(x(i) - 1) .gt. PRECISION) THEN
+            errors = errors + 1
+          END IF
+        END DO
+
+        IF (errors .eq. 0) THEN
+          test1 = .FALSE.
+        ELSE
+          test1 = .TRUE.
+        END IF
+      END FUNCTION
+#endif
+
+#ifndef T2
+!T2:data,structured-data,construct-independent,capture-modifier,V:3.4
+      LOGICAL FUNCTION test2()
+        USE OPENACC
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: i
+        INTEGER :: errors = 0
+        REAL(8), DIMENSION(LOOPCOUNT) :: a
+
+        a = -1
+
+        !$acc data copyout(capture:a(1:LOOPCOUNT))
+          !$acc parallel loop copyout(a(1:LOOPCOUNT))
+          DO i = 1, LOOPCOUNT
+            a(i) = i
+          END DO
+        !$acc end data
+
+        DO i = 1, LOOPCOUNT
+          IF (abs(a(i) - real(i,8)) .gt. PRECISION) THEN
+            errors = errors + 1
+          END IF
+        END DO
+
+        IF (errors .eq. 0) THEN
+          test2 = .FALSE.
+        ELSE
+          test2 = .TRUE.
+        END IF
+      END FUNCTION
+#endif
+
+#ifndef T3
+!T3:data,structured-data,construct-independent,capture-modifier,V:3.4
+      LOGICAL FUNCTION test3()
+        USE OPENACC
+        IMPLICIT NONE
+        INCLUDE "acc_testsuite.Fh"
+        INTEGER :: i
+        INTEGER :: errors = 0
+        REAL(8), DIMENSION(LOOPCOUNT) :: a, a_ref, b
+
+        SEEDDIM(1) = 1
+#       ifdef SEED
+        SEEDDIM(1) = SEED
+#       endif
+        CALL RANDOM_SEED(PUT=SEEDDIM)
+        CALL RANDOM_NUMBER(a)
+        a_ref = a
+        b = -1
+
+        !$acc data copy(a(1:LOOPCOUNT)) create(capture:b(1:LOOPCOUNT))
+          !$acc parallel loop present(a(1:LOOPCOUNT), b(1:LOOPCOUNT))
+          DO i = 1, LOOPCOUNT
+            b(i) = 1
+          END DO
+
+          !$acc parallel loop present(a(1:LOOPCOUNT), b(1:LOOPCOUNT))
+          DO i = 1, LOOPCOUNT
+            a(i) = a(i) + b(i)
+          END DO
+        !$acc end data
+
+        DO i = 1, LOOPCOUNT
+          IF (abs(a(i) - (a_ref(i) + 1)) .gt. PRECISION) THEN
+            errors = errors + 1
+          END IF
+          IF (abs(b(i) - (-1.0D0)) .gt. PRECISION) THEN
+            errors = errors + 1
+          END IF
+        END DO
+
+        IF (errors .eq. 0) THEN
+          test3 = .FALSE.
+        ELSE
+          test3 = .TRUE.
+        END IF
+      END FUNCTION
+#endif
+
+      PROGRAM main
+        IMPLICIT NONE
+        INTEGER :: failcode, testrun
+        LOGICAL :: failed
+        INCLUDE "acc_testsuite.Fh"
+#ifndef T1
+        LOGICAL :: test1
+#endif
+#ifndef T2
+        LOGICAL :: test2
+#endif
+#ifndef T3
+        LOGICAL :: test3
+#endif
+
+        failcode = 0
+        failed = .FALSE.
+
+#ifndef T1
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .or. test1()
+        END DO
+        IF (failed) THEN
+          failcode = failcode + 2 ** 0
+          failed = .FALSE.
+        END IF
+#endif
+
+#ifndef T2
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .or. test2()
+        END DO
+        IF (failed) THEN
+          failcode = failcode + 2 ** 1
+          failed = .FALSE.
+        END IF
+#endif
+
+#ifndef T3
+        DO testrun = 1, NUM_TEST_CALLS
+          failed = failed .or. test3()
+        END DO
+        IF (failed) THEN
+          failcode = failcode + 2 ** 2
+          failed = .FALSE.
+        END IF
+#endif
+
+        CALL EXIT(failcode)
+      END PROGRAM

--- a/Tests/capture.c
+++ b/Tests/capture.c
@@ -1,15 +1,32 @@
-#include "acc_testsuite.h"
+// capture.c
+//
+// Feature under test (OpenACC 3.4, Sections 2.7.4, 2.7.9, and 2.7.10, April 2026):
+// The capture modifier was added to data clauses to specify that a variable
+// requires a discrete device-accessible copy, even when the implementation
+// might otherwise use shared memory between the host and device.
+//
+// Tests:
+// T1 – copy(capture:...): Verifies that a captured copy is created at the
+//      start of a data region. The host modifies the variable after entry,
+//      and the device computation must use the original captured values.
+// T2 – copyout(capture:...): Verifies that a captured device copy is used
+//      during execution and that results are correctly copied back to the
+//      host at region exit. Host-side modifications after capture must not
+//      affect device computation.
+// T3 – create(capture:...): Verifies that a captured device-only copy is
+//      created and used across compute regions. The host version of the
+//      variable is modified after capture, and the device must use its own
+//      independent copy while the host value remains unchanged.
 
+#include "acc_testsuite.h"
 #ifndef T1
 //T1:data,structured-data,construct-independent,capture-modifier,V:3.4
 int test1() {
     int err = 0;
     real_t *x = (real_t *)malloc(n * sizeof(real_t));
-
     for (int i = 0; i < n; ++i) {
-        x[i] = 0;
+        x[i] = 2;
     }
-
     #pragma acc data copy(capture:x[0:n])
     {
         for (int i = 0; i < n; ++i) {
@@ -23,11 +40,10 @@ int test1() {
     }
 
     for (int i = 0; i < n; ++i) {
-        if (fabs(x[i] - 1) > PRECISION) {
+        if (fabs(x[i] - 3) > PRECISION) {
             err += 1;
         }
     }
-
     free(x);
     return err;
 }
@@ -38,30 +54,32 @@ int test1() {
 int test2() {
     int err = 0;
     real_t *a = (real_t *)malloc(n * sizeof(real_t));
-
     for (int i = 0; i < n; ++i) {
         a[i] = -1;
     }
-
     #pragma acc data copyout(capture:a[0:n])
     {
-        #pragma acc parallel loop copyout(a[0:n])
+        #pragma acc parallel loop present(a[0:n])
         for (int i = 0; i < n; ++i) {
-            a[i] = (real_t)(i + 1);
+            a[i] = 0;
+        }
+        for (int i = 0; i < n; ++i) {
+            a[i] = 5;
+        }
+        #pragma acc parallel loop present(a[0:n])
+        for (int i = 0; i < n; ++i) {
+            a[i] = a[i] + 1;
         }
     }
-
     for (int i = 0; i < n; ++i) {
-        if (fabs(a[i] - (real_t)(i + 1)) > PRECISION) {
+        if (fabs(a[i] - 1) > PRECISION) {
             err += 1;
         }
     }
-
     free(a);
     return err;
 }
 #endif
-
 #ifndef T3
 //T3:data,structured-data,construct-independent,capture-modifier,V:3.4
 int test3() {
@@ -69,47 +87,39 @@ int test3() {
     real_t *a = (real_t *)malloc(n * sizeof(real_t));
     real_t *a_ref = (real_t *)malloc(n * sizeof(real_t));
     real_t *b = (real_t *)malloc(n * sizeof(real_t));
-
     srand(SEED);
     for (int i = 0; i < n; ++i) {
         a[i] = rand() / (real_t)(RAND_MAX / 10);
         a_ref[i] = a[i];
-        b[i] = -1;
+        b[i] = 0;
     }
-
     #pragma acc data copy(a[0:n]) create(capture:b[0:n])
     {
-        #pragma acc parallel loop present(a[0:n], b[0:n])
         for (int i = 0; i < n; ++i) {
-            b[i] = 1;
+            b[i] = 5;
         }
-
         #pragma acc parallel loop present(a[0:n], b[0:n])
         for (int i = 0; i < n; ++i) {
             a[i] = a[i] + b[i];
         }
     }
-
     for (int i = 0; i < n; ++i) {
-        if (fabs(a[i] - (a_ref[i] + 1)) > PRECISION) {
+        if (fabs(a[i] - a_ref[i]) > PRECISION) {
             err += 1;
         }
-        if (fabs(b[i] - (-1)) > PRECISION) {
+        if (fabs(b[i] - 5) > PRECISION) {
             err += 1;
         }
     }
-
     free(a);
     free(a_ref);
     free(b);
     return err;
 }
 #endif
-
 int main() {
     int failcode = 0;
     int failed;
-
 #ifndef T1
     failed = 0;
     for (int x = 0; x < NUM_TEST_CALLS; ++x) {
@@ -119,7 +129,6 @@ int main() {
         failcode = failcode + (1 << 0);
     }
 #endif
-
 #ifndef T2
     failed = 0;
     for (int x = 0; x < NUM_TEST_CALLS; ++x) {
@@ -129,7 +138,6 @@ int main() {
         failcode = failcode + (1 << 1);
     }
 #endif
-
 #ifndef T3
     failed = 0;
     for (int x = 0; x < NUM_TEST_CALLS; ++x) {
@@ -139,6 +147,5 @@ int main() {
         failcode = failcode + (1 << 2);
     }
 #endif
-
     return failcode;
 }

--- a/Tests/capture.c
+++ b/Tests/capture.c
@@ -1,0 +1,144 @@
+#include "acc_testsuite.h"
+
+#ifndef T1
+//T1:data,structured-data,construct-independent,capture-modifier,V:3.4
+int test1() {
+    int err = 0;
+    real_t *x = (real_t *)malloc(n * sizeof(real_t));
+
+    for (int i = 0; i < n; ++i) {
+        x[i] = 0;
+    }
+
+    #pragma acc data copy(capture:x[0:n])
+    {
+        for (int i = 0; i < n; ++i) {
+            x[i] = 1;
+        }
+
+        #pragma acc parallel loop copy(x[0:n])
+        for (int i = 0; i < n; ++i) {
+            x[i] = x[i] + 1;
+        }
+    }
+
+    for (int i = 0; i < n; ++i) {
+        if (fabs(x[i] - 1) > PRECISION) {
+            err += 1;
+        }
+    }
+
+    free(x);
+    return err;
+}
+#endif
+
+#ifndef T2
+//T2:data,structured-data,construct-independent,capture-modifier,V:3.4
+int test2() {
+    int err = 0;
+    real_t *a = (real_t *)malloc(n * sizeof(real_t));
+
+    for (int i = 0; i < n; ++i) {
+        a[i] = -1;
+    }
+
+    #pragma acc data copyout(capture:a[0:n])
+    {
+        #pragma acc parallel loop copyout(a[0:n])
+        for (int i = 0; i < n; ++i) {
+            a[i] = (real_t)(i + 1);
+        }
+    }
+
+    for (int i = 0; i < n; ++i) {
+        if (fabs(a[i] - (real_t)(i + 1)) > PRECISION) {
+            err += 1;
+        }
+    }
+
+    free(a);
+    return err;
+}
+#endif
+
+#ifndef T3
+//T3:data,structured-data,construct-independent,capture-modifier,V:3.4
+int test3() {
+    int err = 0;
+    real_t *a = (real_t *)malloc(n * sizeof(real_t));
+    real_t *a_ref = (real_t *)malloc(n * sizeof(real_t));
+    real_t *b = (real_t *)malloc(n * sizeof(real_t));
+
+    srand(SEED);
+    for (int i = 0; i < n; ++i) {
+        a[i] = rand() / (real_t)(RAND_MAX / 10);
+        a_ref[i] = a[i];
+        b[i] = -1;
+    }
+
+    #pragma acc data copy(a[0:n]) create(capture:b[0:n])
+    {
+        #pragma acc parallel loop present(a[0:n], b[0:n])
+        for (int i = 0; i < n; ++i) {
+            b[i] = 1;
+        }
+
+        #pragma acc parallel loop present(a[0:n], b[0:n])
+        for (int i = 0; i < n; ++i) {
+            a[i] = a[i] + b[i];
+        }
+    }
+
+    for (int i = 0; i < n; ++i) {
+        if (fabs(a[i] - (a_ref[i] + 1)) > PRECISION) {
+            err += 1;
+        }
+        if (fabs(b[i] - (-1)) > PRECISION) {
+            err += 1;
+        }
+    }
+
+    free(a);
+    free(a_ref);
+    free(b);
+    return err;
+}
+#endif
+
+int main() {
+    int failcode = 0;
+    int failed;
+
+#ifndef T1
+    failed = 0;
+    for (int x = 0; x < NUM_TEST_CALLS; ++x) {
+        failed = failed + test1();
+    }
+    if (failed != 0) {
+        failcode = failcode + (1 << 0);
+    }
+#endif
+
+#ifndef T2
+    failed = 0;
+    for (int x = 0; x < NUM_TEST_CALLS; ++x) {
+        failed = failed + test2();
+    }
+    if (failed != 0) {
+        failcode = failcode + (1 << 1);
+    }
+#endif
+
+#ifndef T3
+    failed = 0;
+    for (int x = 0; x < NUM_TEST_CALLS; ++x) {
+        failed = failed + test3();
+    }
+    if (failed != 0) {
+        failcode = failcode + (1 << 2);
+    }
+#endif
+
+    return failcode;
+}

--- a/Tests/capture.cpp
+++ b/Tests/capture.cpp
@@ -1,115 +1,122 @@
-#include "acc_testsuite.h"
+// capture.cpp
+//
+// Feature under test (OpenACC 3.4, Sections 2.7.4, 2.7.9, and 2.7.10, April 2026):
+// The capture modifier was added to data clauses to specify that a variable
+// requires a discrete device-accessible copy, even when the implementation
+// might otherwise use shared memory between the host and device.
+//
+// Tests:
+// T1 – copy(capture:...): Verifies that a captured copy is created at the
+//      start of a data region. The host modifies the variable after entry,
+//      and the device computation must use the original captured values.
+// T2 – copyout(capture:...): Verifies that a captured device copy is used
+//      during execution and that results are correctly copied back to the
+//      host at region exit. Host-side modifications after capture must not
+//      affect device computation.
+// T3 – create(capture:...): Verifies that a captured device-only copy is
+//      created and used across compute regions. The host version of the
+//      variable is modified after capture, and the device must use its own
+//      independent copy while the host value remains unchanged.
 
+#include "acc_testsuite.h"
 #ifndef T1
 //T1:data,structured-data,construct-independent,capture-modifier,V:3.4
 int test1() {
     int err = 0;
-    real_t *x = new real_t[n];
-
+    real_t *x = (real_t *)malloc(n * sizeof(real_t));
     for (int i = 0; i < n; ++i) {
-        x[i] = 0;
+        x[i] = 2;
     }
-
     #pragma acc data copy(capture:x[0:n])
     {
         for (int i = 0; i < n; ++i) {
             x[i] = 1;
         }
-
         #pragma acc parallel loop copy(x[0:n])
         for (int i = 0; i < n; ++i) {
             x[i] = x[i] + 1;
         }
     }
-
     for (int i = 0; i < n; ++i) {
-        if (fabs(x[i] - 1) > PRECISION) {
+        if (fabs(x[i] - 3) > PRECISION) {
             err += 1;
         }
     }
-
-    delete[] x;
+    free(x);
     return err;
 }
 #endif
-
 #ifndef T2
 //T2:data,structured-data,construct-independent,capture-modifier,V:3.4
 int test2() {
     int err = 0;
-    real_t *a = new real_t[n];
-
+    real_t *a = (real_t *)malloc(n * sizeof(real_t));
     for (int i = 0; i < n; ++i) {
         a[i] = -1;
     }
-
     #pragma acc data copyout(capture:a[0:n])
     {
-        #pragma acc parallel loop copyout(a[0:n])
+        #pragma acc parallel loop present(a[0:n])
         for (int i = 0; i < n; ++i) {
-            a[i] = (real_t)(i + 1);
+            a[i] = 0;
+        }
+        for (int i = 0; i < n; ++i) {
+            a[i] = 5;
+        }
+        #pragma acc parallel loop present(a[0:n])
+        for (int i = 0; i < n; ++i) {
+            a[i] = a[i] + 1;
         }
     }
-
     for (int i = 0; i < n; ++i) {
-        if (fabs(a[i] - (real_t)(i + 1)) > PRECISION) {
+        if (fabs(a[i] - 1) > PRECISION) {
             err += 1;
         }
     }
-
-    delete[] a;
+    free(a);
     return err;
 }
 #endif
-
 #ifndef T3
 //T3:data,structured-data,construct-independent,capture-modifier,V:3.4
 int test3() {
     int err = 0;
-    real_t *a = new real_t[n];
-    real_t *a_ref = new real_t[n];
-    real_t *b = new real_t[n];
-
+    real_t *a = (real_t *)malloc(n * sizeof(real_t));
+    real_t *a_ref = (real_t *)malloc(n * sizeof(real_t));
+    real_t *b = (real_t *)malloc(n * sizeof(real_t));
     srand(SEED);
     for (int i = 0; i < n; ++i) {
         a[i] = rand() / (real_t)(RAND_MAX / 10);
         a_ref[i] = a[i];
-        b[i] = -1;
+        b[i] = 0;
     }
-
     #pragma acc data copy(a[0:n]) create(capture:b[0:n])
     {
-        #pragma acc parallel loop present(a[0:n], b[0:n])
         for (int i = 0; i < n; ++i) {
-            b[i] = 1;
+            b[i] = 5;
         }
-
         #pragma acc parallel loop present(a[0:n], b[0:n])
         for (int i = 0; i < n; ++i) {
             a[i] = a[i] + b[i];
         }
     }
-
     for (int i = 0; i < n; ++i) {
-        if (fabs(a[i] - (a_ref[i] + 1)) > PRECISION) {
+        if (fabs(a[i] - a_ref[i]) > PRECISION) {
             err += 1;
         }
-        if (fabs(b[i] - (-1)) > PRECISION) {
+        if (fabs(b[i] - 5) > PRECISION) {
             err += 1;
         }
     }
-
-    delete[] a;
-    delete[] a_ref;
-    delete[] b;
+    free(a);
+    free(a_ref);
+    free(b);
     return err;
 }
 #endif
-
 int main() {
     int failcode = 0;
     int failed;
-
 #ifndef T1
     failed = 0;
     for (int x = 0; x < NUM_TEST_CALLS; ++x) {
@@ -119,7 +126,6 @@ int main() {
         failcode = failcode + (1 << 0);
     }
 #endif
-
 #ifndef T2
     failed = 0;
     for (int x = 0; x < NUM_TEST_CALLS; ++x) {
@@ -129,7 +135,6 @@ int main() {
         failcode = failcode + (1 << 1);
     }
 #endif
-
 #ifndef T3
     failed = 0;
     for (int x = 0; x < NUM_TEST_CALLS; ++x) {
@@ -139,6 +144,5 @@ int main() {
         failcode = failcode + (1 << 2);
     }
 #endif
-
     return failcode;
 }

--- a/Tests/capture.cpp
+++ b/Tests/capture.cpp
@@ -1,0 +1,144 @@
+#include "acc_testsuite.h"
+
+#ifndef T1
+//T1:data,structured-data,construct-independent,capture-modifier,V:3.4
+int test1() {
+    int err = 0;
+    real_t *x = new real_t[n];
+
+    for (int i = 0; i < n; ++i) {
+        x[i] = 0;
+    }
+
+    #pragma acc data copy(capture:x[0:n])
+    {
+        for (int i = 0; i < n; ++i) {
+            x[i] = 1;
+        }
+
+        #pragma acc parallel loop copy(x[0:n])
+        for (int i = 0; i < n; ++i) {
+            x[i] = x[i] + 1;
+        }
+    }
+
+    for (int i = 0; i < n; ++i) {
+        if (fabs(x[i] - 1) > PRECISION) {
+            err += 1;
+        }
+    }
+
+    delete[] x;
+    return err;
+}
+#endif
+
+#ifndef T2
+//T2:data,structured-data,construct-independent,capture-modifier,V:3.4
+int test2() {
+    int err = 0;
+    real_t *a = new real_t[n];
+
+    for (int i = 0; i < n; ++i) {
+        a[i] = -1;
+    }
+
+    #pragma acc data copyout(capture:a[0:n])
+    {
+        #pragma acc parallel loop copyout(a[0:n])
+        for (int i = 0; i < n; ++i) {
+            a[i] = (real_t)(i + 1);
+        }
+    }
+
+    for (int i = 0; i < n; ++i) {
+        if (fabs(a[i] - (real_t)(i + 1)) > PRECISION) {
+            err += 1;
+        }
+    }
+
+    delete[] a;
+    return err;
+}
+#endif
+
+#ifndef T3
+//T3:data,structured-data,construct-independent,capture-modifier,V:3.4
+int test3() {
+    int err = 0;
+    real_t *a = new real_t[n];
+    real_t *a_ref = new real_t[n];
+    real_t *b = new real_t[n];
+
+    srand(SEED);
+    for (int i = 0; i < n; ++i) {
+        a[i] = rand() / (real_t)(RAND_MAX / 10);
+        a_ref[i] = a[i];
+        b[i] = -1;
+    }
+
+    #pragma acc data copy(a[0:n]) create(capture:b[0:n])
+    {
+        #pragma acc parallel loop present(a[0:n], b[0:n])
+        for (int i = 0; i < n; ++i) {
+            b[i] = 1;
+        }
+
+        #pragma acc parallel loop present(a[0:n], b[0:n])
+        for (int i = 0; i < n; ++i) {
+            a[i] = a[i] + b[i];
+        }
+    }
+
+    for (int i = 0; i < n; ++i) {
+        if (fabs(a[i] - (a_ref[i] + 1)) > PRECISION) {
+            err += 1;
+        }
+        if (fabs(b[i] - (-1)) > PRECISION) {
+            err += 1;
+        }
+    }
+
+    delete[] a;
+    delete[] a_ref;
+    delete[] b;
+    return err;
+}
+#endif
+
+int main() {
+    int failcode = 0;
+    int failed;
+
+#ifndef T1
+    failed = 0;
+    for (int x = 0; x < NUM_TEST_CALLS; ++x) {
+        failed = failed + test1();
+    }
+    if (failed != 0) {
+        failcode = failcode + (1 << 0);
+    }
+#endif
+
+#ifndef T2
+    failed = 0;
+    for (int x = 0; x < NUM_TEST_CALLS; ++x) {
+        failed = failed + test2();
+    }
+    if (failed != 0) {
+        failcode = failcode + (1 << 1);
+    }
+#endif
+
+#ifndef T3
+    failed = 0;
+    for (int x = 0; x < NUM_TEST_CALLS; ++x) {
+        failed = failed + test3();
+    }
+    if (failed != 0) {
+        failcode = failcode + (1 << 2);
+    }
+#endif
+
+    return failcode;
+}


### PR DESCRIPTION
### PR Description
This PR adds new OpenACC Validation & Verification tests for the capture modifier introduced in OpenACC 3.4

The capture modifier ensures that a variable is given a discrete device-accessible copy, even when the implementation might otherwise treat the variable as residing in shared memory. This feature improves portability and consistency of data behavior across different memory models.

### Feature Being Tested
OpenACC 3.4 introduces the capture modifier for data clauses, allowing it to appear on structured data and compute constructs. The modifier enforces that a separate device copy is created and used during execution.

This PR tests capture in the context of the following clauses:
  •copy
  •copyout
  •create

### Test Descriptions

T1 - copy(capture:...)
   • Verifies that a captured copy is created at the beginning of a data region.
   • The host array is modified after entering the region.
   • The device computation must use the original captured values, not the updated host values.
   • Confirms correct snapshot semantics of capture by observing different host and device values.

T2 - copyout(capture:...)
   • Verifies that a captured device copy is created and used independently of the host.
   • The device array is initialized on the device, then the host array is modified afterward.
   • The device computation must use its captured values and not reflect later host updates.
   • Confirms correct isolation of device memory and proper copyout of final results to the host.

T3 - create(capture:...)
   • Verifies that a captured device-only copy is created and used across compute regions.
   • The host version of the variable is modified after capture.
   • The device computation must use its own captured copy, not the updated host values.
   • Confirms that the device copy remains independent and that the host value is unchanged (no implicit copyout).

### Compiler Testing

### NVHPC 26.1
   • Results: PASS
   • All tests compiled successfully
   • All tests executed with return code 0
   • Compiler output shows expected data clauses (copy, copyout, create)
   • Indicates support for OpenACC 3.4 capture modifier.

### GCC 15.2.0
   • Results: FAIL
   • Errors indicate capture is not recognized in data clauses.
   • Suggests lack of OpenACC 3.4 capture support.

### CRAY 18.0.0
   • Results: FAIL
   • Similar parsing errors as GCC.
   • capture treated as an undeclared identifier.
   • Indicates feature not yet supported.

### Conclusion
   • The added tests correctly exercise the semantics of the OpenACC 3.4 capture modifier.
   • NVHPC demonstrates support for the feature with correct runtime behavior.
   • GCC and Cray compilers currently do not support the capture modifier in data clauses.
   • These tests provide meaningful coverage for a new 3.4 feature and help track compiler adoption.