### PR TITLE
[bug] Fix an error in serial_private.F90

### DIFF
--- a/Tests/serial_private.F90
+++ b/Tests/serial_private.F90
@@ -44,7 +44,7 @@
     DO x = 1, LOOPCOUNT
       temp = temp + (a(x, y) + b(x, y))
     END DO
-    IF (abs(d(x) - temp) .gt. (2 * PRECISION * LOOPCOUNT)) THEN
+    IF (abs(d(y) - temp) .gt. (2 * PRECISION * LOOPCOUNT)) THEN
       errors = errors + 1
     END IF
   END DO


### PR DESCRIPTION
https://github.com/OpenACCUserGroup/OpenACCV-V/issues/132

should by `d(y)` instead of `d(x)`